### PR TITLE
feat(open): add configurable open rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Jupyter notebook JSON previews and notebook icons.
 - Added default theme icons for Angular project files, CSV/TSV tables, object files, libraries, and WebAssembly modules.
 - Added Kitty 0.47+ drag-and-drop support for dropping items into elio and dragging items out, with themed drag previews.
+- Added configurable open rules for choosing preferred openers by file type, extension, and platform, including terminal apps such as `$EDITOR` without changing system defaults. ([#232])
 
 ### Changed
 
@@ -282,6 +283,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/elio-fm/elio/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/elio-fm/elio/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/elio-fm/elio/releases/tag/v1.0.0
+[#232]: https://github.com/elio-fm/elio/issues/232
 [#223]: https://github.com/elio-fm/elio/issues/223
 [#215]: https://github.com/elio-fm/elio/issues/215
 [#201]: https://github.com/elio-fm/elio/issues/201

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,4 +1,4 @@
-# Copy to ~/.config/elio/config.toml to customize Elio's behavior.
+# Copy to ~/.config/elio/config.toml to customize elio's behavior.
 
 # [ui]
 # show_top_bar = false
@@ -57,20 +57,24 @@
 # ]
 #
 # Override elio's open action without changing system defaults. Rules are
-# checked top-to-bottom; if none match, elio uses the system opener.
+# checked top-to-bottom; put specific extension rules before broad type rules.
+# If none match, elio uses the system opener. Omit platform to match every OS.
 #
 # Match by elio file type and/or extension. Supported types: folder, text, code,
 # config, document, image, audio, video, archive, font, data, file.
-# `command` is split like a small shell command; if {path} is omitted, elio
-# appends selected matching paths. Use terminal = true for terminal apps so elio
-# suspends, waits, and restores after the command exits.
+# Without {path}, elio appends opened paths. Use {path} only when the app needs
+# the path inside an argument; then bulk opens run once per path.
+# Use terminal = true for terminal apps so elio suspends, waits, and restores.
+# For Windows paths with backslashes, prefer TOML literal strings.
 #
 # [open]
 # rules = [
+#   { ext = "md", command = "markdown-app", platform = "linux" },
 #   { type = ["text", "code", "config"], command = "$EDITOR", terminal = true },
-#   { ext = "pdf", command = "zathura", platform = ["linux", "bsd"] },
-#   { ext = "pdf", command = "open -a Preview", platform = "macos" },
-#   { ext = "pdf", command = "SumatraPDF.exe", platform = "windows" },
+#   { ext = "pdf", command = "pdf-app", platform = ["linux", "bsd"] },
+#   { ext = "pdf", command = "open -a App", platform = "macos" },
+#   { ext = "pdf", command = "pdf-app.exe", platform = "windows" },
+#   # or: { ext = "pdf", command = 'C:\Program Files\App\app.exe', platform = "windows" },
 # ]
 #
 # Optional pane weights for the browser body. Values are relative: in
@@ -78,7 +82,7 @@
 # below Files they control the Files / Preview vertical split.
 # Set a pane to 0 to hide it.
 #
-# If this table is omitted, Elio keeps the built-in responsive layout:
+# If this table is omitted, elio keeps the built-in responsive layout:
 # - horizontal layout: Places prefers 20 cols, Files / Preview use a 54 / 46
 #   split of the remaining width
 # - tighter windows: Places can shrink to 18 cols before Preview stacks

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -56,6 +56,23 @@
 #   { title = "tmp", path = "/tmp", key = "T" },
 # ]
 #
+# Override elio's open action without changing system defaults. Rules are
+# checked top-to-bottom; if none match, elio uses the system opener.
+#
+# Match by elio file type and/or extension. Supported types: folder, text, code,
+# config, document, image, audio, video, archive, font, data, file.
+# `command` is split like a small shell command; if {path} is omitted, elio
+# appends selected matching paths. Use terminal = true for terminal apps so elio
+# suspends, waits, and restores after the command exits.
+#
+# [open]
+# rules = [
+#   { type = ["text", "code", "config"], command = "$EDITOR", terminal = true },
+#   { ext = "pdf", command = "zathura", platform = ["linux", "bsd"] },
+#   { ext = "pdf", command = "open -a Preview", platform = "macos" },
+#   { ext = "pdf", command = "SumatraPDF.exe", platform = "windows" },
+# ]
+#
 # Optional pane weights for the browser body. Values are relative: in
 # side-by-side layouts they control horizontal width, and when Preview stacks
 # below Files they control the Files / Preview vertical split.

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -411,6 +411,22 @@ impl App {
     }
 
     pub(in crate::app) fn open_in_system(&mut self) -> Result<()> {
+        let entries = self.open_target_entries();
+        match crate::app::open_rules::plans_for_entries(&entries) {
+            Ok(plans)
+                if plans.iter().any(|plan| {
+                    !matches!(plan, crate::app::open_rules::OpenPlan::System { .. })
+                }) =>
+            {
+                return self.run_open_plans(plans);
+            }
+            Err(error) => {
+                self.status = error;
+                return Ok(());
+            }
+            _ => {}
+        }
+
         #[cfg(all(unix, not(target_os = "macos")))]
         if let Some(entry) = self.single_file_open_target_entry() {
             if self.queue_terminal_default_open_if_needed(&entry) {
@@ -430,6 +446,21 @@ impl App {
     }
 
     fn open_entry_in_system(&mut self, entry: &Entry) -> Result<()> {
+        match crate::app::open_rules::plans_for_entries(std::slice::from_ref(entry)) {
+            Ok(plans)
+                if plans.iter().any(|plan| {
+                    !matches!(plan, crate::app::open_rules::OpenPlan::System { .. })
+                }) =>
+            {
+                return self.run_open_plans(plans);
+            }
+            Err(error) => {
+                self.status = error;
+                return Ok(());
+            }
+            _ => {}
+        }
+
         #[cfg(all(unix, not(target_os = "macos")))]
         {
             if self.queue_terminal_default_open_if_needed(entry) {
@@ -475,6 +506,62 @@ impl App {
         });
         self.status.clear();
         true
+    }
+
+    fn run_open_plans(&mut self, plans: Vec<crate::app::open_rules::OpenPlan>) -> Result<()> {
+        let mut opened = 0usize;
+        let mut total = 0usize;
+        let mut last_error = None;
+        let mut terminal_commands = Vec::new();
+
+        for plan in plans {
+            match plan {
+                crate::app::open_rules::OpenPlan::System { paths } => {
+                    total += paths.len();
+                    for path in &paths {
+                        match crate::fs::open_in_system(path) {
+                            Ok(()) => opened += 1,
+                            Err(error) => last_error = Some(error),
+                        }
+                    }
+                }
+                crate::app::open_rules::OpenPlan::Detached { program, args } => {
+                    total += 1;
+                    match crate::fs::detached_open_command(&program, &args) {
+                        Ok(()) => opened += 1,
+                        Err(error) => last_error = Some(format!("{program}: {error}")),
+                    }
+                }
+                crate::app::open_rules::OpenPlan::Terminal { program, args } => {
+                    total += 1;
+                    opened += 1;
+                    terminal_commands.push((program, args));
+                }
+            }
+        }
+
+        if !terminal_commands.is_empty() {
+            self.pending_terminal_task = if terminal_commands.len() == 1 {
+                let (program, args) = terminal_commands.remove(0);
+                Some(crate::app::PendingTerminalTask::Command { program, args })
+            } else {
+                Some(crate::app::PendingTerminalTask::Commands(terminal_commands))
+            };
+            self.status.clear();
+            return Ok(());
+        }
+
+        self.status = match (total, opened, last_error) {
+            (0, _, _) => String::new(),
+            (1, 1, _) => "Opened item".to_string(),
+            (_, opened, None) => format!("Opened {opened} items"),
+            (1, 0, Some(error)) => error,
+            (_, 0, Some(error)) => format!("Failed to open {total} items: {error}"),
+            (_, opened, Some(error)) => {
+                format!("Opened {opened}/{total} items; last error: {error}")
+            }
+        };
+        Ok(())
     }
 
     fn open_paths_in_system(&mut self, targets: Vec<PathBuf>) -> Result<()> {
@@ -536,6 +623,25 @@ impl App {
             .map(|entry| vec![entry.path.clone()])
             .unwrap_or_default()
     }
+
+    fn open_target_entries(&self) -> Vec<Entry> {
+        if !self.navigation.selected_paths.is_empty() {
+            return self
+                .selected_paths_sorted()
+                .into_iter()
+                .filter_map(|path| {
+                    self.navigation
+                        .entries
+                        .iter()
+                        .find(|entry| entry.path == path)
+                        .cloned()
+                        .or_else(|| entry_from_existing_path(&path))
+                })
+                .collect();
+        }
+
+        self.selected_entry().cloned().into_iter().collect()
+    }
 }
 
 fn open_status_name(path: &Path) -> String {
@@ -546,10 +652,12 @@ fn open_status_name(path: &Path) -> String {
 
 #[cfg(all(unix, not(target_os = "macos")))]
 fn entry_from_existing_file(path: &Path) -> Option<Entry> {
+    entry_from_existing_path(path).filter(|entry| !entry.is_dir())
+}
+
+fn entry_from_existing_path(path: &Path) -> Option<Entry> {
     let name = path.file_name()?.to_string_lossy().into_owned();
-    crate::fs::entry_from_path(path.to_path_buf(), name)
-        .ok()
-        .filter(|entry| !entry.is_dir())
+    crate::fs::entry_from_path(path.to_path_buf(), name).ok()
 }
 
 #[cfg(test)]

--- a/src/app/actions/navigation.rs
+++ b/src/app/actions/navigation.rs
@@ -513,6 +513,7 @@ impl App {
         let mut total = 0usize;
         let mut last_error = None;
         let mut terminal_commands = Vec::new();
+        let mut detached_started = false;
 
         for plan in plans {
             match plan {
@@ -528,7 +529,10 @@ impl App {
                 crate::app::open_rules::OpenPlan::Detached { program, args } => {
                     total += 1;
                     match crate::fs::detached_open_command(&program, &args) {
-                        Ok(()) => opened += 1,
+                        Ok(()) => {
+                            opened += 1;
+                            detached_started = true;
+                        }
                         Err(error) => last_error = Some(format!("{program}: {error}")),
                     }
                 }
@@ -551,14 +555,19 @@ impl App {
             return Ok(());
         }
 
+        let started_status = if detached_started {
+            "Opening"
+        } else {
+            "Opened"
+        };
         self.status = match (total, opened, last_error) {
             (0, _, _) => String::new(),
-            (1, 1, _) => "Opened item".to_string(),
-            (_, opened, None) => format!("Opened {opened} items"),
+            (1, 1, _) => format!("{started_status} item"),
+            (_, opened, None) => format!("{started_status} {opened} items"),
             (1, 0, Some(error)) => error,
             (_, 0, Some(error)) => format!("Failed to open {total} items: {error}"),
             (_, opened, Some(error)) => {
-                format!("Opened {opened}/{total} items; last error: {error}")
+                format!("{started_status} {opened}/{total} items; last error: {error}")
             }
         };
         Ok(())
@@ -675,6 +684,62 @@ mod tests {
             .expect("system time should be after unix epoch")
             .as_nanos();
         std::env::temp_dir().join(format!("elio-navigation-{label}-{unique}"))
+    }
+
+    #[cfg(windows)]
+    fn successful_detached_command() -> (String, Vec<String>) {
+        (
+            "cmd.exe".to_string(),
+            vec!["/C".to_string(), "exit 0".to_string()],
+        )
+    }
+
+    #[cfg(not(windows))]
+    fn successful_detached_command() -> (String, Vec<String>) {
+        (
+            "/bin/sh".to_string(),
+            vec!["-c".to_string(), "true".to_string()],
+        )
+    }
+
+    #[test]
+    fn detached_open_rule_reports_command_launch_failure() {
+        let root = temp_path("detached-open-rule-failure");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+
+        app.run_open_plans(vec![crate::app::open_rules::OpenPlan::Detached {
+            program: "definitely-not-real-elio-command".to_string(),
+            args: Vec::new(),
+        }])
+        .expect("open plan should be handled");
+
+        assert!(
+            app.status_message()
+                .contains("definitely-not-real-elio-command"),
+            "status should report detached command failure, got: {}",
+            app.status_message()
+        );
+
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
+
+    #[test]
+    fn detached_open_rule_uses_opening_status_after_successful_launch() {
+        let root = temp_path("detached-open-rule-opening");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        let mut app = App::new_at(root.clone()).expect("failed to create app");
+
+        let (program, args) = successful_detached_command();
+        app.run_open_plans(vec![crate::app::open_rules::OpenPlan::Detached {
+            program,
+            args,
+        }])
+        .expect("open plan should be handled");
+
+        assert_eq!(app.status_message(), "Opening item");
+
+        fs::remove_dir_all(root).expect("temp directory should be removed");
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8,6 +8,7 @@ mod git;
 mod input;
 mod jobs;
 mod local_filter;
+mod open_rules;
 mod open_with;
 mod overlays;
 use crate::preview;

--- a/src/app/open_rules.rs
+++ b/src/app/open_rules.rs
@@ -164,11 +164,13 @@ fn tokenize_command(command: &str) -> Vec<String> {
         match ch {
             '\'' if !in_double_quotes => in_single_quotes = !in_single_quotes,
             '"' if !in_single_quotes => in_double_quotes = !in_double_quotes,
-            '\\' => {
-                if let Some(next) = chars.next() {
+            '\\' => match chars.peek().copied() {
+                Some(next) if matches!(next, ' ' | '\t' | '\'' | '"' | '\\') => {
+                    chars.next();
                     current.push(next);
                 }
-            }
+                _ => current.push(ch),
+            },
             ' ' | '\t' if !in_single_quotes && !in_double_quotes => {
                 if !current.is_empty() {
                     tokens.push(std::mem::take(&mut current));
@@ -181,7 +183,46 @@ fn tokenize_command(command: &str) -> Vec<String> {
     if !current.is_empty() {
         tokens.push(current);
     }
+    coalesce_windows_executable_path(tokens)
+}
+
+fn coalesce_windows_executable_path(tokens: Vec<String>) -> Vec<String> {
+    if tokens.len() < 2 || !looks_like_windows_path_start(&tokens[0]) {
+        return tokens;
+    }
+
+    let mut program = String::new();
+    for (index, token) in tokens.iter().enumerate() {
+        if index > 0 {
+            program.push(' ');
+        }
+        program.push_str(token);
+
+        if looks_like_windows_executable_path(&program) {
+            let mut merged = Vec::with_capacity(tokens.len() - index);
+            merged.push(program);
+            merged.extend(tokens[index + 1..].iter().cloned());
+            return merged;
+        }
+    }
+
     tokens
+}
+
+fn looks_like_windows_path_start(token: &str) -> bool {
+    let bytes = token.as_bytes();
+    (bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/'))
+        || token.starts_with(r"\\")
+}
+
+fn looks_like_windows_executable_path(path: &str) -> bool {
+    let path = path.to_ascii_lowercase();
+    [".exe", ".cmd", ".bat", ".com"]
+        .iter()
+        .any(|suffix| path.ends_with(suffix))
 }
 
 fn expand_args(args: &[String], paths: &[PathBuf]) -> Vec<String> {
@@ -261,6 +302,55 @@ mod tests {
         assert_eq!(
             tokenize_command("open -a \"Preview App\" {path}"),
             vec!["open", "-a", "Preview App", "{path}"]
+        );
+    }
+
+    #[test]
+    fn preserves_backslashes_that_are_not_command_escapes() {
+        assert_eq!(
+            tokenize_command(r#"echo C:\tmp\notes.txt"#),
+            vec!["echo", r#"C:\tmp\notes.txt"#]
+        );
+    }
+
+    #[test]
+    fn still_supports_escaped_unix_whitespace() {
+        assert_eq!(
+            tokenize_command(r#"my\ command --flag"#),
+            vec!["my command", "--flag"]
+        );
+    }
+
+    #[test]
+    fn tokenizes_quoted_windows_command_path() {
+        assert_eq!(
+            tokenize_command(r#""C:\Program Files\SumatraPDF\SumatraPDF.exe" -reuse-instance"#),
+            vec![
+                r#"C:\Program Files\SumatraPDF\SumatraPDF.exe"#,
+                "-reuse-instance"
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenizes_unquoted_windows_command_path_with_spaces() {
+        assert_eq!(
+            tokenize_command(r#"C:\Program Files\SumatraPDF\SumatraPDF.exe -reuse-instance"#),
+            vec![
+                r#"C:\Program Files\SumatraPDF\SumatraPDF.exe"#,
+                "-reuse-instance"
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenizes_windows_forward_slash_command_path_with_spaces() {
+        assert_eq!(
+            tokenize_command(r#"C:/Program Files/SumatraPDF/SumatraPDF.exe -reuse-instance"#),
+            vec![
+                "C:/Program Files/SumatraPDF/SumatraPDF.exe",
+                "-reuse-instance"
+            ]
         );
     }
 

--- a/src/app/open_rules.rs
+++ b/src/app/open_rules.rs
@@ -1,0 +1,301 @@
+use std::{env, path::PathBuf};
+
+use crate::{
+    config::{self, OpenPlatform, OpenRule, OpenTargetType},
+    core::{Entry, EntryKind, FileClass},
+    file_info::{self, PreviewKind},
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(in crate::app) enum OpenPlan {
+    System { paths: Vec<PathBuf> },
+    Detached { program: String, args: Vec<String> },
+    Terminal { program: String, args: Vec<String> },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CommandTemplate {
+    program: String,
+    args: Vec<String>,
+    has_path_placeholder: bool,
+}
+
+pub(in crate::app) fn plans_for_entries(entries: &[Entry]) -> Result<Vec<OpenPlan>, String> {
+    let mut plans = Vec::new();
+    let current_platform = OpenPlatform::current();
+    for entry in entries {
+        let Some(rule) = matching_rule(entry, current_platform) else {
+            push_system(&mut plans, entry.path.clone());
+            continue;
+        };
+        let command = command_template(&rule.command)?;
+        if command.has_path_placeholder {
+            let args = expand_args(&command.args, std::slice::from_ref(&entry.path));
+            push_command_plan(&mut plans, rule.terminal, command.program, args, false);
+        } else {
+            let mut args = command.args;
+            args.push(entry.path.to_string_lossy().into_owned());
+            push_command_plan(&mut plans, rule.terminal, command.program, args, true);
+        }
+    }
+    Ok(plans)
+}
+
+fn matching_rule(entry: &Entry, platform: OpenPlatform) -> Option<&'static OpenRule> {
+    config::open()
+        .rules
+        .iter()
+        .find(|rule| rule_matches(rule, entry, platform))
+}
+
+fn rule_matches(rule: &OpenRule, entry: &Entry, platform: OpenPlatform) -> bool {
+    (rule.platforms.is_empty() || rule.platforms.contains(&platform))
+        && (rule.exts.is_empty() || entry_ext_matches(entry, &rule.exts))
+        && (rule.types.is_empty() || entry_type_matches(entry, &rule.types))
+}
+
+fn entry_ext_matches(entry: &Entry, exts: &[String]) -> bool {
+    let Some(ext) = entry
+        .path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+    else {
+        return false;
+    };
+    exts.iter().any(|candidate| candidate == &ext)
+}
+
+fn entry_type_matches(entry: &Entry, types: &[OpenTargetType]) -> bool {
+    let facts = file_info::inspect_entry_cached(entry);
+    types
+        .iter()
+        .any(|target_type| entry_has_type(entry, facts, *target_type))
+}
+
+fn entry_has_type(entry: &Entry, facts: file_info::FileFacts, target_type: OpenTargetType) -> bool {
+    match target_type {
+        OpenTargetType::Folder => entry.kind == EntryKind::Directory,
+        OpenTargetType::Text => entry_is_text_like(entry, facts),
+        OpenTargetType::Code => facts.builtin_class == FileClass::Code,
+        OpenTargetType::Config => facts.builtin_class == FileClass::Config,
+        OpenTargetType::Document => facts.builtin_class == FileClass::Document,
+        OpenTargetType::Image => facts.builtin_class == FileClass::Image,
+        OpenTargetType::Audio => facts.builtin_class == FileClass::Audio,
+        OpenTargetType::Video => facts.builtin_class == FileClass::Video,
+        OpenTargetType::Archive => facts.builtin_class == FileClass::Archive,
+        OpenTargetType::Font => facts.builtin_class == FileClass::Font,
+        OpenTargetType::Data => facts.builtin_class == FileClass::Data,
+        OpenTargetType::File => facts.builtin_class == FileClass::File,
+    }
+}
+
+fn entry_is_text_like(entry: &Entry, facts: file_info::FileFacts) -> bool {
+    if entry.kind == EntryKind::Directory {
+        return false;
+    }
+    if matches!(
+        facts.builtin_class,
+        FileClass::Code | FileClass::Config | FileClass::License
+    ) {
+        return true;
+    }
+    match facts.preview.kind {
+        PreviewKind::Markdown | PreviewKind::Csv | PreviewKind::Source => true,
+        PreviewKind::PlainText => {
+            facts.preview.document_format.is_none()
+                && !matches!(
+                    facts.builtin_class,
+                    FileClass::Image
+                        | FileClass::Audio
+                        | FileClass::Video
+                        | FileClass::Archive
+                        | FileClass::Font
+                )
+        }
+        PreviewKind::Sqlite
+        | PreviewKind::SqliteCandidate
+        | PreviewKind::Iso
+        | PreviewKind::Torrent => false,
+    }
+}
+
+fn command_template(command: &str) -> Result<CommandTemplate, String> {
+    let command = command.trim();
+    let tokens = if command == "$EDITOR" {
+        editor_tokens()?
+    } else {
+        tokenize_command(command)
+    };
+    let mut tokens = tokens.into_iter();
+    let Some(program) = tokens.next() else {
+        return Err("Open command is empty".to_string());
+    };
+    let args: Vec<String> = tokens.collect();
+    let has_path_placeholder = args.iter().any(|arg| arg.contains("{path}"));
+    Ok(CommandTemplate {
+        program,
+        args,
+        has_path_placeholder,
+    })
+}
+
+fn editor_tokens() -> Result<Vec<String>, String> {
+    for key in ["VISUAL", "EDITOR"] {
+        let Some(value) = env::var_os(key).and_then(|value| value.into_string().ok()) else {
+            continue;
+        };
+        let tokens = tokenize_command(&value);
+        if !tokens.is_empty() {
+            return Ok(tokens);
+        }
+    }
+    Err("$EDITOR is not set".to_string())
+}
+
+fn tokenize_command(command: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut chars = command.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\'' if !in_double_quotes => in_single_quotes = !in_single_quotes,
+            '"' if !in_single_quotes => in_double_quotes = !in_double_quotes,
+            '\\' => {
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
+            }
+            ' ' | '\t' if !in_single_quotes && !in_double_quotes => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+fn expand_args(args: &[String], paths: &[PathBuf]) -> Vec<String> {
+    let mut expanded = Vec::new();
+    for arg in args {
+        if arg == "{path}" {
+            expanded.extend(paths.iter().map(|path| path.to_string_lossy().into_owned()));
+        } else if arg.contains("{path}") {
+            for path in paths {
+                expanded.push(arg.replace("{path}", &path.to_string_lossy()));
+            }
+        } else {
+            expanded.push(arg.clone());
+        }
+    }
+    expanded
+}
+
+fn push_system(plans: &mut Vec<OpenPlan>, path: PathBuf) {
+    if let Some(OpenPlan::System { paths }) = plans.last_mut() {
+        paths.push(path);
+    } else {
+        plans.push(OpenPlan::System { paths: vec![path] });
+    }
+}
+
+fn push_command_plan(
+    plans: &mut Vec<OpenPlan>,
+    terminal: bool,
+    program: String,
+    args: Vec<String>,
+    merge_append_path: bool,
+) {
+    if !merge_append_path {
+        if terminal {
+            plans.push(OpenPlan::Terminal { program, args });
+        } else {
+            plans.push(OpenPlan::Detached { program, args });
+        }
+        return;
+    }
+
+    if let Some(last) = plans.last_mut() {
+        let args_prefix = args[..args.len().saturating_sub(1)].to_vec();
+        match last {
+            OpenPlan::Terminal {
+                program: last_program,
+                args: last_args,
+            } if terminal && last_program == &program && last_args.starts_with(&args_prefix) => {
+                last_args.extend(args.last().cloned());
+                return;
+            }
+            OpenPlan::Detached {
+                program: last_program,
+                args: last_args,
+            } if !terminal && last_program == &program && last_args.starts_with(&args_prefix) => {
+                last_args.extend(args.last().cloned());
+                return;
+            }
+            _ => {}
+        }
+    }
+
+    if terminal {
+        plans.push(OpenPlan::Terminal { program, args });
+    } else {
+        plans.push(OpenPlan::Detached { program, args });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenizes_quoted_command() {
+        assert_eq!(
+            tokenize_command("open -a \"Preview App\" {path}"),
+            vec!["open", "-a", "Preview App", "{path}"]
+        );
+    }
+
+    #[test]
+    fn expands_embedded_path_placeholder_once_per_path() {
+        let paths = vec![PathBuf::from("a.md"), PathBuf::from("b.md")];
+        assert_eq!(
+            expand_args(&["--file={path}".to_string()], &paths),
+            vec!["--file=a.md", "--file=b.md"]
+        );
+    }
+
+    #[test]
+    fn appends_paths_to_matching_command_group() {
+        let mut plans = Vec::new();
+        push_command_plan(
+            &mut plans,
+            true,
+            "hx".to_string(),
+            vec!["--foo".to_string(), "a.md".to_string()],
+            true,
+        );
+        push_command_plan(
+            &mut plans,
+            true,
+            "hx".to_string(),
+            vec!["--foo".to_string(), "b.md".to_string()],
+            true,
+        );
+        assert_eq!(
+            plans,
+            vec![OpenPlan::Terminal {
+                program: "hx".to_string(),
+                args: vec!["--foo".to_string(), "a.md".to_string(), "b.md".to_string()],
+            }]
+        );
+    }
+}

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -747,6 +747,7 @@ pub(in crate::app) struct InputRuntime {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum PendingTerminalTask {
     Command { program: String, args: Vec<String> },
+    Commands(Vec<(String, Vec<String>)>),
     Shell { cwd: PathBuf },
     Zoxide,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,7 @@ mod goto;
 mod keys;
 mod layout;
 mod loading;
+mod open;
 mod places;
 #[cfg(test)]
 mod tests;
@@ -14,6 +15,7 @@ pub(crate) use self::{
     keys::{Action, ChooserKeyAction, KeyBindings, KeyContext, KeyList, normalized_plain_key_char},
     layout::{LayoutConfig, PaneWeights},
     loading::config_dir,
+    open::{OpenConfig, OpenPlatform, OpenRule, OpenTargetType},
     places::{BuiltinPlace, PlaceEntrySpec, PlacesConfig},
     ui::UiConfig,
 };
@@ -24,6 +26,7 @@ struct Config {
     places: PlacesConfig,
     layout: LayoutConfig,
     keys: KeyBindings,
+    open: OpenConfig,
 }
 
 #[derive(Deserialize, Default)]
@@ -33,6 +36,7 @@ struct ConfigFile {
     places: Option<places::PlacesConfigOverride>,
     layout: Option<layout::LayoutConfigOverride>,
     keys: Option<keys::KeysConfigOverride>,
+    open: Option<open::OpenConfigOverride>,
 }
 
 pub(crate) fn initialize() {
@@ -59,6 +63,10 @@ pub(crate) fn keys() -> &'static KeyBindings {
     &loading::active_config().keys
 }
 
+pub(crate) fn open() -> &'static OpenConfig {
+    &loading::active_config().open
+}
+
 impl Config {
     fn default_config() -> Self {
         Self {
@@ -67,6 +75,7 @@ impl Config {
             places: PlacesConfig::default(),
             layout: LayoutConfig::default(),
             keys: KeyBindings::default(),
+            open: OpenConfig::default(),
         }
     }
 
@@ -90,6 +99,9 @@ impl Config {
         }
         if let Some(keys) = parsed.keys {
             resolved.keys = KeyBindings::from_override(keys, &KeyBindings::default());
+        }
+        if let Some(open) = parsed.open {
+            resolved.open = OpenConfig::from_override(open, &resolved.open);
         }
         Ok(resolved)
     }

--- a/src/config/open.rs
+++ b/src/config/open.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct OpenConfig {
@@ -41,10 +42,16 @@ pub(crate) enum OpenPlatform {
 #[derive(Deserialize, Default)]
 pub(super) struct OpenConfigOverride {
     rules: Option<Vec<toml::Value>>,
+    #[serde(flatten)]
+    unknown: BTreeMap<String, toml::Value>,
 }
 
 impl OpenConfig {
     pub(super) fn from_override(overrides: OpenConfigOverride, defaults: &Self) -> Self {
+        for key in overrides.unknown.keys() {
+            eprintln!("elio: open.{key}: unknown open config key; ignoring");
+        }
+
         let mut resolved = defaults.clone();
         if let Some(rules) = overrides.rules {
             resolved.rules = rules
@@ -61,10 +68,21 @@ impl OpenConfig {
 
 impl OpenRule {
     fn from_toml_value(value: &toml::Value, field_name: &str) -> Option<Self> {
+        const FIELDS: &[&str] = &["type", "ext", "platform", "command", "terminal"];
+
         let toml::Value::Table(table) = value else {
             eprintln!("elio: {field_name}: expected an open rule object; skipping rule");
             return None;
         };
+
+        for key in table.keys() {
+            if !FIELDS.contains(&key.as_str()) {
+                eprintln!(
+                    "elio: {field_name}: unknown field {key:?}; expected type, ext, platform, command, terminal; skipping rule"
+                );
+                return None;
+            }
+        }
 
         let types = parse_type_list(table.get("type"), field_name)?;
         let exts = parse_ext_list(table.get("ext"), field_name)?;

--- a/src/config/open.rs
+++ b/src/config/open.rs
@@ -1,0 +1,244 @@
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct OpenConfig {
+    pub rules: Vec<OpenRule>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct OpenRule {
+    pub types: Vec<OpenTargetType>,
+    pub exts: Vec<String>,
+    pub platforms: Vec<OpenPlatform>,
+    pub command: String,
+    pub terminal: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OpenTargetType {
+    Folder,
+    Text,
+    Code,
+    Config,
+    Document,
+    Image,
+    Audio,
+    Video,
+    Archive,
+    Font,
+    Data,
+    File,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OpenPlatform {
+    Linux,
+    Bsd,
+    Macos,
+    Windows,
+}
+
+#[derive(Deserialize, Default)]
+pub(super) struct OpenConfigOverride {
+    rules: Option<Vec<toml::Value>>,
+}
+
+impl OpenConfig {
+    pub(super) fn from_override(overrides: OpenConfigOverride, defaults: &Self) -> Self {
+        let mut resolved = defaults.clone();
+        if let Some(rules) = overrides.rules {
+            resolved.rules = rules
+                .iter()
+                .enumerate()
+                .filter_map(|(index, value)| {
+                    OpenRule::from_toml_value(value, &format!("open.rules[{index}]"))
+                })
+                .collect();
+        }
+        resolved
+    }
+}
+
+impl OpenRule {
+    fn from_toml_value(value: &toml::Value, field_name: &str) -> Option<Self> {
+        let toml::Value::Table(table) = value else {
+            eprintln!("elio: {field_name}: expected an open rule object; skipping rule");
+            return None;
+        };
+
+        let types = parse_type_list(table.get("type"), field_name)?;
+        let exts = parse_ext_list(table.get("ext"), field_name)?;
+        let platforms = parse_platform_list(table.get("platform"), field_name)?;
+        let terminal = parse_bool(table.get("terminal"), field_name, "terminal")?;
+
+        if types.is_empty() && exts.is_empty() {
+            eprintln!(
+                "elio: {field_name}: open rules require at least one type or ext matcher; skipping rule"
+            );
+            return None;
+        }
+
+        let command = table
+            .get("command")
+            .and_then(toml::Value::as_str)
+            .map(str::trim)
+            .filter(|command| !command.is_empty());
+        let Some(command) = command else {
+            eprintln!(
+                "elio: {field_name}: open rules require a non-empty string command; skipping rule"
+            );
+            return None;
+        };
+
+        Some(Self {
+            types,
+            exts,
+            platforms,
+            command: command.to_string(),
+            terminal,
+        })
+    }
+}
+
+fn parse_type_list(value: Option<&toml::Value>, field_name: &str) -> Option<Vec<OpenTargetType>> {
+    parse_string_or_list(value, field_name, "type", OpenTargetType::parse)
+}
+
+fn parse_ext_list(value: Option<&toml::Value>, field_name: &str) -> Option<Vec<String>> {
+    parse_string_or_list(value, field_name, "ext", |ext| {
+        let ext = ext.trim().trim_start_matches('.').to_ascii_lowercase();
+        (!ext.is_empty()).then_some(ext)
+    })
+}
+
+fn parse_platform_list(value: Option<&toml::Value>, field_name: &str) -> Option<Vec<OpenPlatform>> {
+    parse_string_or_list(value, field_name, "platform", OpenPlatform::parse)
+}
+
+fn parse_string_or_list<T>(
+    value: Option<&toml::Value>,
+    field_name: &str,
+    key: &str,
+    mut parse: impl FnMut(&str) -> Option<T>,
+) -> Option<Vec<T>> {
+    let Some(value) = value else {
+        return Some(Vec::new());
+    };
+
+    match value {
+        toml::Value::String(item) => {
+            parse_one(item, field_name, key, &mut parse).map(|item| vec![item])
+        }
+        toml::Value::Array(items) => {
+            let mut parsed = Vec::new();
+            for item in items {
+                let Some(item) = item.as_str() else {
+                    eprintln!("elio: {field_name}: {key} entries must be strings; skipping rule");
+                    return None;
+                };
+                parsed.push(parse_one(item, field_name, key, &mut parse)?);
+            }
+            Some(parsed)
+        }
+        _ => {
+            eprintln!(
+                "elio: {field_name}: {key} must be a string or list of strings; skipping rule"
+            );
+            None
+        }
+    }
+}
+
+fn parse_one<T>(
+    item: &str,
+    field_name: &str,
+    key: &str,
+    parse: &mut impl FnMut(&str) -> Option<T>,
+) -> Option<T> {
+    let Some(parsed) = parse(item) else {
+        eprintln!("elio: {field_name}: unknown {key} value {item:?}; skipping rule");
+        return None;
+    };
+    Some(parsed)
+}
+
+fn parse_bool(value: Option<&toml::Value>, field_name: &str, key: &str) -> Option<bool> {
+    let Some(value) = value else {
+        return Some(false);
+    };
+    match value {
+        toml::Value::Boolean(value) => Some(*value),
+        _ => {
+            eprintln!("elio: {field_name}: {key} must be true or false; skipping rule");
+            None
+        }
+    }
+}
+
+impl OpenTargetType {
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "folder" | "directory" | "dir" => Some(Self::Folder),
+            "text" => Some(Self::Text),
+            "code" => Some(Self::Code),
+            "config" => Some(Self::Config),
+            "document" | "doc" => Some(Self::Document),
+            "image" => Some(Self::Image),
+            "audio" => Some(Self::Audio),
+            "video" => Some(Self::Video),
+            "archive" => Some(Self::Archive),
+            "font" => Some(Self::Font),
+            "data" => Some(Self::Data),
+            "file" => Some(Self::File),
+            _ => None,
+        }
+    }
+}
+
+impl OpenPlatform {
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "linux" => Some(Self::Linux),
+            "bsd" | "freebsd" | "openbsd" | "netbsd" | "dragonfly" => Some(Self::Bsd),
+            "macos" | "mac" | "darwin" => Some(Self::Macos),
+            "windows" | "win" => Some(Self::Windows),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn current() -> Self {
+        #[cfg(target_os = "linux")]
+        {
+            Self::Linux
+        }
+        #[cfg(any(
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "dragonfly"
+        ))]
+        {
+            Self::Bsd
+        }
+        #[cfg(target_os = "macos")]
+        {
+            Self::Macos
+        }
+        #[cfg(windows)]
+        {
+            Self::Windows
+        }
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "dragonfly",
+            target_os = "macos",
+            windows
+        )))]
+        {
+            Self::Linux
+        }
+    }
+}

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -1,6 +1,7 @@
 mod goto;
 mod keys;
 mod layout;
+mod open;
 mod places;
 mod ui;
 

--- a/src/config/tests/open.rs
+++ b/src/config/tests/open.rs
@@ -1,0 +1,61 @@
+use super::super::*;
+
+#[test]
+fn config_defaults_open_rules_to_empty() {
+    let config = Config::default_config();
+    assert!(config.open.rules.is_empty());
+}
+
+#[test]
+fn config_parses_open_rules_with_string_and_list_fields() {
+    let config = Config::from_str(
+        r#"
+[open]
+rules = [
+  { type = ["text", "code"], ext = "md", command = "$EDITOR", terminal = true },
+  { ext = ["pdf", ".epub"], command = "open -a Preview", platform = "macos" },
+  { type = "image", command = "imv", platform = ["linux", "bsd"] },
+]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.open.rules.len(), 3);
+    assert_eq!(
+        config.open.rules[0].types,
+        vec![OpenTargetType::Text, OpenTargetType::Code]
+    );
+    assert_eq!(config.open.rules[0].exts, vec!["md"]);
+    assert_eq!(config.open.rules[0].command, "$EDITOR");
+    assert!(config.open.rules[0].terminal);
+
+    assert_eq!(config.open.rules[1].exts, vec!["pdf", "epub"]);
+    assert_eq!(config.open.rules[1].platforms, vec![OpenPlatform::Macos]);
+
+    assert_eq!(config.open.rules[2].types, vec![OpenTargetType::Image]);
+    assert_eq!(
+        config.open.rules[2].platforms,
+        vec![OpenPlatform::Linux, OpenPlatform::Bsd]
+    );
+}
+
+#[test]
+fn config_skips_invalid_open_rules_without_failing_parse() {
+    let config = Config::from_str(
+        r#"
+[open]
+rules = [
+  { type = "unknown", command = "bad" },
+  { ext = "", command = "bad" },
+  { ext = "md" },
+  { command = "missing matcher" },
+  { ext = "txt", command = "hx" },
+]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.open.rules.len(), 1);
+    assert_eq!(config.open.rules[0].exts, vec!["txt"]);
+    assert_eq!(config.open.rules[0].command, "hx");
+}

--- a/src/config/tests/open.rs
+++ b/src/config/tests/open.rs
@@ -59,3 +59,39 @@ rules = [
     assert_eq!(config.open.rules[0].exts, vec!["txt"]);
     assert_eq!(config.open.rules[0].command, "hx");
 }
+
+#[test]
+fn config_skips_open_rules_with_unknown_fields_without_dropping_valid_rules() {
+    let config = Config::from_str(
+        r#"
+[open]
+rules = [
+  { ext = "pdf", command = "bad", plaform = "linux" },
+  { ext = "txt", command = "hx" },
+]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.open.rules.len(), 1);
+    assert_eq!(config.open.rules[0].exts, vec!["txt"]);
+    assert_eq!(config.open.rules[0].command, "hx");
+}
+
+#[test]
+fn config_ignores_unknown_open_keys_without_dropping_rules() {
+    let config = Config::from_str(
+        r#"
+[open]
+rulez = []
+rules = [
+  { ext = "txt", command = "hx" },
+]
+"#,
+    )
+    .expect("config should parse");
+
+    assert_eq!(config.open.rules.len(), 1);
+    assert_eq!(config.open.rules[0].exts, vec!["txt"]);
+    assert_eq!(config.open.rules[0].command, "hx");
+}

--- a/src/fs/opener.rs
+++ b/src/fs/opener.rs
@@ -203,6 +203,13 @@ fn detached_spawn(command: &mut Command) -> io::Result<()> {
     command.stderr(Stdio::null());
     #[cfg(unix)]
     command.process_group(0);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const DETACHED_PROCESS: u32 = 0x00000008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+        command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
     command.spawn()?;
     Ok(())
 }

--- a/src/fs/opener.rs
+++ b/src/fs/opener.rs
@@ -6,7 +6,11 @@ use std::{
     io,
     path::Path,
     process::{Command, Stdio},
+    time::Duration,
 };
+
+const DETACHED_COMMAND_DEADLINE: Duration = Duration::from_millis(250);
+const DETACHED_COMMAND_POLL: Duration = Duration::from_millis(10);
 
 #[cfg(test)]
 thread_local! {
@@ -179,7 +183,11 @@ pub(crate) fn detached_open(program: &str, args: &[&str], target: &Path) -> io::
         return status_spawn(&mut command);
     }
 
-    detached_spawn(&mut command)
+    detached_spawn_with_deadline(
+        &mut command,
+        DETACHED_COMMAND_DEADLINE,
+        DETACHED_COMMAND_POLL,
+    )
 }
 
 /// Spawns `program` with the given `args` detached from the terminal.
@@ -194,10 +202,41 @@ pub(crate) fn detached_open_command(program: &str, args: &[String]) -> io::Resul
         return status_spawn(&mut command);
     }
 
-    detached_spawn(&mut command)
+    detached_spawn_with_deadline(
+        &mut command,
+        DETACHED_COMMAND_DEADLINE,
+        DETACHED_COMMAND_POLL,
+    )
 }
 
-fn detached_spawn(command: &mut Command) -> io::Result<()> {
+fn detached_spawn_with_deadline(
+    command: &mut Command,
+    deadline_duration: Duration,
+    poll: Duration,
+) -> io::Result<()> {
+    use std::time::Instant;
+
+    prepare_detached_command(command);
+    let mut child = command.spawn()?;
+
+    let deadline = Instant::now() + deadline_duration;
+    while Instant::now() < deadline {
+        match child.try_wait()? {
+            Some(status) if status.success() => return Ok(()),
+            Some(status) => {
+                return Err(io::Error::other(format!("process exited with {status}")));
+            }
+            None => std::thread::sleep(poll),
+        }
+    }
+
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+    Ok(())
+}
+
+fn prepare_detached_command(command: &mut Command) {
     command.stdin(Stdio::null());
     command.stdout(Stdio::null());
     command.stderr(Stdio::null());
@@ -210,8 +249,6 @@ fn detached_spawn(command: &mut Command) -> io::Result<()> {
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
         command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
     }
-    command.spawn()?;
-    Ok(())
 }
 
 #[cfg(target_os = "macos")]
@@ -310,6 +347,43 @@ mod tests {
         assert_ne!(pgid, unsafe { libc::getpgrp() });
 
         fs::remove_dir_all(root).expect("failed to remove temp root");
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn detached_open_command_reports_immediate_nonzero_exit() {
+        let mut command = Command::new("/bin/sh");
+        command.arg("-c").arg("exit 7");
+
+        let result = detached_spawn_with_deadline(
+            &mut command,
+            std::time::Duration::from_secs(5),
+            std::time::Duration::from_millis(10),
+        );
+
+        let error = result.expect_err("immediate nonzero exit should be reported");
+        assert!(
+            error.to_string().contains("process exited with"),
+            "error should report child exit status, got: {error}"
+        );
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn detached_open_command_detaches_when_deadline_expires() {
+        let mut command = Command::new("/bin/sh");
+        command.arg("-c").arg("sleep 1");
+
+        let result = detached_spawn_with_deadline(
+            &mut command,
+            std::time::Duration::ZERO,
+            std::time::Duration::from_millis(10),
+        );
+
+        assert!(
+            result.is_ok(),
+            "deadline expiry should detach the still-running child: {result:?}"
+        );
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -441,6 +441,16 @@ fn run_app(
                         pause_runtime_input(&input_reader, false);
                         None
                     }
+                    PendingTerminalTask::Commands(commands) => {
+                        pause_runtime_input(&input_reader, true);
+                        suspend_terminal(terminal, drainer, true, kitty_dnd)?;
+                        for (program, args) in commands {
+                            run_blocking_in_terminal(&program, &args);
+                        }
+                        resume_terminal(terminal, drainer, kitty_dnd)?;
+                        pause_runtime_input(&input_reader, false);
+                        None
+                    }
                     PendingTerminalTask::Shell { cwd } => {
                         pause_runtime_input(&input_reader, true);
                         suspend_terminal(terminal, drainer, true, kitty_dnd)?;


### PR DESCRIPTION
## Summary

Add configurable open rules so users can choose preferred openers by file type, extension, and platform without changing system defaults.

Rules are evaluated in order, can match elio file types such as `text`, `code`, `config`, `document`, `image`, `archive`, `folder`, and `data`, and can use extension-specific entries for exceptions. Commands can launch terminal apps or detached GUI openers, with support for custom command strings, `$EDITOR`, `{path}`, and platform-specific rules.

Closes #232.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested open rules on Linux, macOS, Windows, and FreeBSD, covering terminal editors, GUI openers, platform-specific rules, config warnings, launch errors, and system-opener fallback.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed