### PR TITLE
feat(theme): improve file type icons and templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a show/hide control to encrypted archive password prompts.
 - Added YAML frontmatter rendering to Markdown previews and recognized Quarto `.qmd` files as Markdown. ([#223])
 - Added syntax-highlighted previews for Astro `.astro` files.
+- Added file type labels and icons for subtitle files and Coccinelle semantic patches, including diff-style previews for `.cocci` files.
 - Added Jupyter notebook JSON previews and notebook icons.
 - Added default theme icons for Angular project files, CSV/TSV tables, object files, libraries, and WebAssembly modules.
 - Added Kitty 0.47+ drag-and-drop support for dropping items into elio and dragging items out, with themed drag previews.
@@ -24,11 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Made create and bulk rename overlays show more rows before scrolling, adapt better on short terminals, and use consistent scrollbar styling.
-- Dimmed help overlay key separators and removed the bottom close hint.
+- Dimmed help overlay key separators (`/`) and removed the bottom close hint.
+- Improved default and example theme icons for `.gitkeep`, Makefile variants, `Kyuafile`, `config` directories, subtitle files, and diff/patch previews.
 
 ### Fixed
 
 - Fixed Fuzzy Find result icons for nested files that use full-name rules, such as `LICENSE.md`.
+- Fixed `.in` templates such as `Makefile.in`, `Kyuafile.in`, and shell completion templates being shown as plain files.
+- Fixed extensionless shell scripts with SPDX headers being shown as license files.
 
 ## [1.10.0] - 2026-06-30
 

--- a/assets/themes/default/theme.toml
+++ b/assets/themes/default/theme.toml
@@ -265,8 +265,38 @@ color = "#8c97a8"
 
 [extensions.srt]
 class = "document"
-icon = "󰈙"
-color = "#8ddf6d"
+icon = "󰨖"
+color = "#6f66ff"
+
+[extensions.vtt]
+class = "document"
+icon = "󰨖"
+color = "#6f66ff"
+
+[extensions.ass]
+class = "document"
+icon = "󰨖"
+color = "#6f66ff"
+
+[extensions.ssa]
+class = "document"
+icon = "󰨖"
+color = "#6f66ff"
+
+[extensions.ttml]
+class = "document"
+icon = "󰨖"
+color = "#6f66ff"
+
+[extensions.sbv]
+class = "document"
+icon = "󰨖"
+color = "#6f66ff"
+
+[extensions.smi]
+class = "document"
+icon = "󰨖"
+color = "#6f66ff"
 
 [extensions.keys]
 class = "config"
@@ -441,6 +471,11 @@ color = "#79b8ff"
 [extensions.cpp]
 class = "code"
 icon = ""
+color = "#8cb8ff"
+
+[extensions.cocci]
+class = "code"
+icon = ""
 color = "#8cb8ff"
 
 [extensions.h]
@@ -708,6 +743,11 @@ class = "config"
 icon = "󰊢"
 color = "#d78eff"
 
+[files.".gitkeep"]
+class = "config"
+icon = "󰊢"
+color = "#d78eff"
+
 [files.".env"]
 class = "config"
 icon = "󰒓"
@@ -922,6 +962,21 @@ color = "#d6def0"
 class = "config"
 icon = ""
 color = "#ff9b61"
+
+[files."GNUmakefile"]
+class = "config"
+icon = ""
+color = "#ff9b61"
+
+[files."BSDmakefile"]
+class = "config"
+icon = ""
+color = "#ff9b61"
+
+[files."Kyuafile"]
+class = "config"
+icon = ""
+color = "#7aaeff"
 
 [files."PKGBUILD"]
 class = "config"
@@ -1280,7 +1335,7 @@ icon = "󰉋"
 color = "#5ba8ff"
 
 [directories."config"]
-icon = "󰒓"
+icon = "󱁿"
 color = "#5ba8ff"
 
 [directories."docs"]

--- a/examples/themes/amber-dusk/theme.toml
+++ b/examples/themes/amber-dusk/theme.toml
@@ -303,7 +303,7 @@ icon = "󰉋"
 color = "#cf9c67"
 
 [directories."config"]
-icon = "󰒓"
+icon = "󱁿"
 color = "#cf9c67"
 
 [directories."docs"]
@@ -414,6 +414,41 @@ color = "#c4a27a"
 class = "document"
 icon = "󰈙"
 color = "#cd766d"
+
+[extensions.srt]
+class = "document"
+icon = "󰨖"
+color = "#af89bf"
+
+[extensions.vtt]
+class = "document"
+icon = "󰨖"
+color = "#af89bf"
+
+[extensions.ass]
+class = "document"
+icon = "󰨖"
+color = "#af89bf"
+
+[extensions.ssa]
+class = "document"
+icon = "󰨖"
+color = "#af89bf"
+
+[extensions.ttml]
+class = "document"
+icon = "󰨖"
+color = "#af89bf"
+
+[extensions.sbv]
+class = "document"
+icon = "󰨖"
+color = "#af89bf"
+
+[extensions.smi]
+class = "document"
+icon = "󰨖"
+color = "#af89bf"
 
 [extensions.epub]
 class = "document"

--- a/examples/themes/blush-light/theme.toml
+++ b/examples/themes/blush-light/theme.toml
@@ -122,6 +122,41 @@ class = "document"
 icon = "󰈙"
 color = "#d96c7a"
 
+[extensions.srt]
+class = "document"
+icon = "󰨖"
+color = "#a08dd1"
+
+[extensions.vtt]
+class = "document"
+icon = "󰨖"
+color = "#a08dd1"
+
+[extensions.ass]
+class = "document"
+icon = "󰨖"
+color = "#a08dd1"
+
+[extensions.ssa]
+class = "document"
+icon = "󰨖"
+color = "#a08dd1"
+
+[extensions.ttml]
+class = "document"
+icon = "󰨖"
+color = "#a08dd1"
+
+[extensions.sbv]
+class = "document"
+icon = "󰨖"
+color = "#a08dd1"
+
+[extensions.smi]
+class = "document"
+icon = "󰨖"
+color = "#a08dd1"
+
 [extensions.epub]
 class = "document"
 icon = "󱗖"
@@ -407,7 +442,17 @@ class = "document"
 icon = ""
 color = "#bb907b"
 
+[files."Kyuafile"]
+class = "config"
+icon = ""
+color = "#9f82c6"
+
 [files.".gitignore"]
+class = "config"
+icon = "󰊢"
+color = "#b78fcd"
+
+[files.".gitkeep"]
 class = "config"
 icon = "󰊢"
 color = "#b78fcd"
@@ -855,7 +900,7 @@ icon = "󰉋"
 color = "#d46b93"
 
 [directories."config"]
-icon = "󰒓"
+icon = "󱁿"
 color = "#d46b93"
 
 [directories."docs"]

--- a/examples/themes/catppuccin-mocha/theme.toml
+++ b/examples/themes/catppuccin-mocha/theme.toml
@@ -303,7 +303,7 @@ icon = "󰉋"
 color = "#89b4fa"
 
 [directories."config"]
-icon = "󰒓"
+icon = "󱁿"
 color = "#89b4fa"
 
 [directories."docs"]
@@ -605,8 +605,38 @@ color = "#9399b2"
 
 [extensions.srt]
 class = "document"
-icon = "󰈙"
-color = "#a6e3a1"
+icon = "󰨖"
+color = "#b4befe"
+
+[extensions.vtt]
+class = "document"
+icon = "󰨖"
+color = "#b4befe"
+
+[extensions.ass]
+class = "document"
+icon = "󰨖"
+color = "#b4befe"
+
+[extensions.ssa]
+class = "document"
+icon = "󰨖"
+color = "#b4befe"
+
+[extensions.ttml]
+class = "document"
+icon = "󰨖"
+color = "#b4befe"
+
+[extensions.sbv]
+class = "document"
+icon = "󰨖"
+color = "#b4befe"
+
+[extensions.smi]
+class = "document"
+icon = "󰨖"
+color = "#b4befe"
 
 [files."Cargo.lock"]
 class = "data"
@@ -683,7 +713,17 @@ class = "document"
 icon = "󰭘"
 color = "#b4befe"
 
+[files."Kyuafile"]
+class = "config"
+icon = ""
+color = "#89b4fa"
+
 [files.".gitignore"]
+class = "config"
+icon = "󰊢"
+color = "#cba6f7"
+
+[files.".gitkeep"]
 class = "config"
 icon = "󰊢"
 color = "#cba6f7"

--- a/examples/themes/default-light/theme.toml
+++ b/examples/themes/default-light/theme.toml
@@ -303,7 +303,7 @@ icon = "󰉋"
 color = "#5ba8ff"
 
 [directories."config"]
-icon = "󰒓"
+icon = "󱁿"
 color = "#5ba8ff"
 
 [directories."docs"]
@@ -605,8 +605,38 @@ color = "#768491"
 
 [extensions.srt]
 class = "document"
-icon = "󰈙"
-color = "#7fb65b"
+icon = "󰨖"
+color = "#7168d9"
+
+[extensions.vtt]
+class = "document"
+icon = "󰨖"
+color = "#7168d9"
+
+[extensions.ass]
+class = "document"
+icon = "󰨖"
+color = "#7168d9"
+
+[extensions.ssa]
+class = "document"
+icon = "󰨖"
+color = "#7168d9"
+
+[extensions.ttml]
+class = "document"
+icon = "󰨖"
+color = "#7168d9"
+
+[extensions.sbv]
+class = "document"
+icon = "󰨖"
+color = "#7168d9"
+
+[extensions.smi]
+class = "document"
+icon = "󰨖"
+color = "#7168d9"
 
 [files."Cargo.lock"]
 class = "data"
@@ -683,7 +713,17 @@ class = "document"
 icon = "󰭘"
 color = "#9c8bb8"
 
+[files."Kyuafile"]
+class = "config"
+icon = ""
+color = "#9278c6"
+
 [files.".gitignore"]
+class = "config"
+icon = "󰊢"
+color = "#9d80cf"
+
+[files.".gitkeep"]
 class = "config"
 icon = "󰊢"
 color = "#9d80cf"

--- a/examples/themes/terminal-ansi/theme.toml
+++ b/examples/themes/terminal-ansi/theme.toml
@@ -86,6 +86,41 @@ color = "ansi-green"
 [classes.file]
 color = "ansi-white"
 
+[extensions.srt]
+class = "document"
+icon = "󰨖"
+color = "ansi-magenta"
+
+[extensions.vtt]
+class = "document"
+icon = "󰨖"
+color = "ansi-magenta"
+
+[extensions.ass]
+class = "document"
+icon = "󰨖"
+color = "ansi-magenta"
+
+[extensions.ssa]
+class = "document"
+icon = "󰨖"
+color = "ansi-magenta"
+
+[extensions.ttml]
+class = "document"
+icon = "󰨖"
+color = "ansi-magenta"
+
+[extensions.sbv]
+class = "document"
+icon = "󰨖"
+color = "ansi-magenta"
+
+[extensions.smi]
+class = "document"
+icon = "󰨖"
+color = "ansi-magenta"
+
 [directories."node_modules"]
 icon = "󰏗"
 color = "ansi-blue"
@@ -171,7 +206,7 @@ icon = "󰉋"
 color = "ansi-blue"
 
 [directories."config"]
-icon = "󰒓"
+icon = "󱁿"
 color = "ansi-blue"
 
 [directories."docs"]

--- a/examples/themes/tokyo-night/theme.toml
+++ b/examples/themes/tokyo-night/theme.toml
@@ -303,7 +303,7 @@ icon = "󰉋"
 color = "#7aa2f7"
 
 [directories."config"]
-icon = "󰒓"
+icon = "󱁿"
 color = "#7aa2f7"
 
 [directories."docs"]
@@ -605,8 +605,38 @@ color = "#9399b2"
 
 [extensions.srt]
 class = "document"
-icon = "󰈙"
-color = "#9ece6a"
+icon = "󰨖"
+color = "#9d7cd8"
+
+[extensions.vtt]
+class = "document"
+icon = "󰨖"
+color = "#9d7cd8"
+
+[extensions.ass]
+class = "document"
+icon = "󰨖"
+color = "#9d7cd8"
+
+[extensions.ssa]
+class = "document"
+icon = "󰨖"
+color = "#9d7cd8"
+
+[extensions.ttml]
+class = "document"
+icon = "󰨖"
+color = "#9d7cd8"
+
+[extensions.sbv]
+class = "document"
+icon = "󰨖"
+color = "#9d7cd8"
+
+[extensions.smi]
+class = "document"
+icon = "󰨖"
+color = "#9d7cd8"
 
 [files."Cargo.lock"]
 class = "data"
@@ -683,7 +713,17 @@ class = "document"
 icon = "󰭘"
 color = "#9d7cd8"
 
+[files."Kyuafile"]
+class = "config"
+icon = ""
+color = "#7aa2f7"
+
 [files.".gitignore"]
+class = "config"
+icon = "󰊢"
+color = "#bb9af7"
+
+[files.".gitkeep"]
 class = "config"
 icon = "󰊢"
 color = "#bb9af7"

--- a/src/file_info/classify.rs
+++ b/src/file_info/classify.rs
@@ -1,5 +1,5 @@
 use super::{
-    FileFacts, PreviewSpec,
+    FileFacts, PreviewKind, PreviewSpec,
     archives::inspect_archive_name,
     extensions::inspect_extension,
     license::{sniff_browser_license_file_type, sniff_license_file_type},
@@ -51,6 +51,8 @@ fn inspect_path_with_name(path: &Path, display_name: Option<&str>, kind: EntryKi
         inspect_path_with_name_base(path, display_name, kind);
     if ext.is_empty() {
         facts = sniff_extensionless_file_type(path).unwrap_or(facts);
+    } else if ext == "in" {
+        facts = sniff_template_file_type(path).unwrap_or(facts);
     } else if matches!(ext.as_str(), "conf" | "cfg") {
         facts = sniff_config_file_type(path).unwrap_or(facts);
     }
@@ -62,7 +64,13 @@ fn inspect_path_with_name_fast(
     display_name: Option<&str>,
     kind: EntryKind,
 ) -> FileFacts {
-    let (_name_for_type, name, ext, facts) = inspect_path_with_name_base(path, display_name, kind);
+    let (_name_for_type, name, ext, mut facts) =
+        inspect_path_with_name_base(path, display_name, kind);
+    if ext.is_empty() {
+        facts = sniff_extensionless_file_type(path).unwrap_or(facts);
+    } else if ext == "in" {
+        facts = sniff_template_file_type(path).unwrap_or(facts);
+    }
     sniff_browser_license_file_type(path, &name, &ext, facts).unwrap_or(facts)
 }
 
@@ -98,6 +106,9 @@ fn inspect_path_with_name_base(
     }
     if let Some(facts) = inspect_archive_name(&name) {
         return (name_for_type, name, String::new(), facts);
+    }
+    if let Some(facts) = inspect_template_name(&name) {
+        return (name_for_type, name, "in".to_string(), facts);
     }
 
     let ext = Path::new(&name_for_type)
@@ -190,6 +201,47 @@ fn normalize_key(input: &str) -> String {
     input.trim().to_ascii_lowercase()
 }
 
+fn inspect_template_name(name: &str) -> Option<FileFacts> {
+    let inner = name.strip_suffix(".in")?;
+    if inner.is_empty() {
+        return None;
+    }
+
+    if let Some(facts) = inspect_exact_name(inner) {
+        return Some(template_facts(inner, facts));
+    }
+
+    let inner_ext = Path::new(inner)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(normalize_key)
+        .unwrap_or_default();
+    if inner_ext.is_empty() {
+        return None;
+    }
+
+    let facts = inspect_extension(&inner_ext);
+    is_template_inner_candidate(facts).then(|| template_facts(&inner_ext, facts))
+}
+
+fn is_template_inner_candidate(facts: FileFacts) -> bool {
+    facts.preview.language_hint.is_some()
+        || facts.preview.structured_format.is_some()
+        || matches!(facts.preview.kind, PreviewKind::Markdown | PreviewKind::Csv)
+}
+
+fn template_facts(inner_key: &str, mut facts: FileFacts) -> FileFacts {
+    facts.specific_type_label = match inner_key {
+        "bash" => Some("Bash template"),
+        "zsh" => Some("Zsh template"),
+        "sh" => Some("Shell template"),
+        "makefile" | "gnumakefile" | "bsdmakefile" => Some("Makefile template"),
+        "kyuafile" => Some("Kyua test config template"),
+        _ => facts.specific_type_label,
+    };
+    facts
+}
+
 fn sniff_extensionless_file_type(path: &Path) -> Option<FileFacts> {
     if !is_regular_file(path) {
         return None;
@@ -200,6 +252,18 @@ fn sniff_extensionless_file_type(path: &Path) -> Option<FileFacts> {
     let bytes_read = file.read(&mut buffer).ok()?;
     let prefix = &buffer[..bytes_read];
     sniff_image_type(prefix).or_else(|| sniff_shebang_script_type(prefix))
+}
+
+fn sniff_template_file_type(path: &Path) -> Option<FileFacts> {
+    if !is_regular_file(path) {
+        return None;
+    }
+
+    let mut file = File::open(path).ok()?;
+    let mut buffer = [0_u8; 512];
+    let bytes_read = file.read(&mut buffer).ok()?;
+    let prefix = &buffer[..bytes_read];
+    sniff_shebang_template_type(prefix).or_else(|| sniff_zsh_completion_template_type(prefix))
 }
 
 fn is_regular_file(path: &Path) -> bool {
@@ -267,6 +331,43 @@ fn sniff_shebang_script_type(buffer: &[u8]) -> Option<FileFacts> {
         specific_type_label: Some(specific_type_label),
         preview: language.preview_spec(),
     })
+}
+
+fn sniff_shebang_template_type(buffer: &[u8]) -> Option<FileFacts> {
+    let text = std::str::from_utf8(buffer).ok()?;
+    let first_line = text.lines().next()?.trim_start_matches('\u{feff}');
+    let interpreter = shebang_interpreter_name(first_line)?;
+    let language = registry::language_for_shebang(interpreter)?;
+
+    Some(FileFacts {
+        builtin_class: FileClass::Code,
+        specific_type_label: template_label_for_language(language.canonical_id),
+        preview: language.preview_spec(),
+    })
+}
+
+fn sniff_zsh_completion_template_type(buffer: &[u8]) -> Option<FileFacts> {
+    let text = std::str::from_utf8(buffer).ok()?;
+    let first_line = text.lines().next()?.trim_start_matches('\u{feff}').trim();
+    if !first_line.starts_with("#compdef") {
+        return None;
+    }
+    let language = registry::language_for_code_syntax("zsh")?;
+
+    Some(FileFacts {
+        builtin_class: FileClass::Code,
+        specific_type_label: Some("Zsh completion template"),
+        preview: language.preview_spec(),
+    })
+}
+
+fn template_label_for_language(language_id: &str) -> Option<&'static str> {
+    match language_id {
+        "bash" => Some("Bash template"),
+        "zsh" => Some("Zsh template"),
+        "sh" => Some("Shell template"),
+        _ => None,
+    }
 }
 
 fn shebang_interpreter_name(first_line: &str) -> Option<&str> {

--- a/src/file_info/extensions.rs
+++ b/src/file_info/extensions.rs
@@ -1,5 +1,5 @@
 use super::types::{disk_image_file_facts, plain, source_only};
-use super::{DiskImageKind, DocumentFormat, FileFacts, PreviewSpec};
+use super::{CodeBackend, DiskImageKind, DocumentFormat, FileFacts, PreviewSpec};
 use crate::{core::FileClass, preview::code::registry};
 
 fn preview_for_extension(ext: &str) -> PreviewSpec {
@@ -119,6 +119,11 @@ pub(super) fn inspect_extension(ext: &str) -> FileFacts {
             }),
             preview: preview_for_extension(ext),
         },
+        "cocci" => FileFacts {
+            builtin_class: FileClass::Code,
+            specific_type_label: Some("Coccinelle semantic patch"),
+            preview: PreviewSpec::code("diff", CodeBackend::Syntect, None),
+        },
         "tex" | "ltx" | "bib" | "sty" | "cls" => FileFacts {
             builtin_class: FileClass::Document,
             specific_type_label: Some(match ext {
@@ -206,7 +211,19 @@ pub(super) fn inspect_extension(ext: &str) -> FileFacts {
         "sha256" => plain(FileClass::Data, Some("SHA-256 checksum")),
         "sha512" => plain(FileClass::Data, Some("SHA-512 checksum")),
         "md5" => plain(FileClass::Data, Some("MD5 checksum")),
-        "srt" => plain(FileClass::Document, Some("SubRip subtitles")),
+        "srt" | "vtt" | "ass" | "ssa" | "ttml" | "sbv" | "smi" => plain(
+            FileClass::Document,
+            Some(match ext {
+                "srt" => "SubRip subtitles",
+                "vtt" => "WebVTT subtitles",
+                "ass" => "ASS subtitles",
+                "ssa" => "SubStation Alpha subtitles",
+                "ttml" => "TTML subtitles",
+                "sbv" => "SBV subtitles",
+                "smi" => "SAMI subtitles",
+                _ => unreachable!("subtitle extension arm only matches known subtitle extensions"),
+            }),
+        ),
         "p12" | "pfx" => plain(FileClass::Config, Some("PKCS#12 certificate")),
         "pem" => plain(FileClass::Config, Some("PEM certificate")),
         "crt" | "cer" => plain(FileClass::Config, Some("Certificate")),

--- a/src/file_info/names.rs
+++ b/src/file_info/names.rs
@@ -19,6 +19,11 @@ pub(super) fn inspect_exact_name(name: &str) -> Option<FileFacts> {
             specific_type_label: Some("Makefile"),
             preview: preview_for_exact_name(name),
         }),
+        "kyuafile" => Some(FileFacts {
+            builtin_class: FileClass::Config,
+            specific_type_label: Some("Kyua test config"),
+            preview: preview_for_exact_name(name),
+        }),
         "cmakelists.txt" => Some(FileFacts {
             builtin_class: FileClass::Config,
             specific_type_label: Some("CMake project"),

--- a/src/file_info/tests/classify.rs
+++ b/src/file_info/tests/classify.rs
@@ -19,6 +19,97 @@ fn extensionless_shebang_scripts_are_classified_as_shell_code() {
 }
 
 #[test]
+fn fast_extensionless_shebang_scripts_are_not_mislabeled_as_licenses() {
+    let (root, path) = write_temp_file(
+        "fast-extensionless-shell-script",
+        "configure",
+        "#!/bin/sh\n\n# SPDX-License-Identifier: ISC\n#\n# configure - POSIX shell build configuration framework\n\nset -e\n",
+    );
+    let metadata = fs::metadata(&path).expect("metadata should exist");
+    let entry = Entry {
+        path: path.clone(),
+        name: "configure".to_string(),
+        name_key: "configure".to_string(),
+        kind: EntryKind::File,
+        symlink: None,
+        size: metadata.len(),
+        modified: metadata.modified().ok(),
+        readonly: false,
+    };
+
+    let facts = inspect_entry_fast(&entry);
+
+    assert_eq!(facts.builtin_class, FileClass::Code);
+    assert_eq!(facts.specific_type_label, Some("Shell script"));
+    assert_eq!(facts.preview.language_hint, Some("sh"));
+    assert_code_spec(facts.preview, Some("sh"), CodeBackend::Syntect);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn input_templates_with_shebangs_use_script_language() {
+    let (root, path) = write_temp_file(
+        "bash-template",
+        "_pkg.bash.in",
+        "#! /usr/bin/env bash\n\n_pkg_complete() {\n    :\n}\n",
+    );
+
+    let facts = inspect_path(&path, EntryKind::File);
+
+    assert_eq!(facts.builtin_class, FileClass::Code);
+    assert_eq!(facts.specific_type_label, Some("Bash template"));
+    assert_eq!(facts.preview.language_hint, Some("bash"));
+    assert_code_spec(facts.preview, Some("bash"), CodeBackend::Syntect);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn zsh_completion_input_templates_are_detected_from_compdef() {
+    let (root, path) = write_temp_file(
+        "zsh-completion-template",
+        "_pkg.in",
+        "#compdef pkg pkg-static\n\n_pkg_cmd() {\n    %prefix%/sbin/pkg \"$@\"\n}\n",
+    );
+
+    let facts = inspect_path(&path, EntryKind::File);
+
+    assert_eq!(facts.builtin_class, FileClass::Code);
+    assert_eq!(facts.specific_type_label, Some("Zsh completion template"));
+    assert_eq!(facts.preview.language_hint, Some("zsh"));
+    assert_code_spec(facts.preview, Some("zsh"), CodeBackend::Syntect);
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn unknown_input_fixtures_stay_plain_files() {
+    let (root, path) = write_temp_file(
+        "unknown-input-fixture",
+        "1.in",
+        "{\n\"key1\": value;\n\"key1\": value2;\n}\n",
+    );
+
+    let facts = inspect_path(&path, EntryKind::File);
+
+    assert_eq!(facts.builtin_class, FileClass::File);
+    assert_eq!(facts.specific_type_label, None);
+    assert_eq!(facts.preview, PreviewSpec::plain_text());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn binary_named_input_templates_stay_plain_files() {
+    let facts = inspect_path(Path::new("logo.png.in"), EntryKind::File);
+
+    assert_eq!(facts.builtin_class, FileClass::File);
+    assert_eq!(facts.specific_type_label, None);
+    assert_eq!(facts.preview, PreviewSpec::plain_text());
+}
+
+#[test]
 fn extensionless_elixir_scripts_are_classified_as_code() {
     let (root, path) = write_temp_file(
         "extensionless-elixir-script",

--- a/src/file_info/tests/extensions.rs
+++ b/src/file_info/tests/extensions.rs
@@ -51,6 +51,25 @@ fn supported_video_extensions_keep_specific_video_labels() {
 }
 
 #[test]
+fn subtitle_extensions_keep_specific_subtitle_labels() {
+    let cases = [
+        ("movie.srt", "SubRip subtitles"),
+        ("movie.vtt", "WebVTT subtitles"),
+        ("movie.ass", "ASS subtitles"),
+        ("movie.ssa", "SubStation Alpha subtitles"),
+        ("movie.ttml", "TTML subtitles"),
+        ("movie.sbv", "SBV subtitles"),
+        ("movie.smi", "SAMI subtitles"),
+    ];
+
+    for (path, label) in cases {
+        let facts = inspect_path(Path::new(path), EntryKind::File);
+        assert_eq!(facts.builtin_class, FileClass::Document, "{path}");
+        assert_eq!(facts.specific_type_label, Some(label), "{path}");
+    }
+}
+
+#[test]
 fn font_files_keep_specific_labels() {
     let cases = [
         ("JetBrainsMono.ttf", "TrueType font"),
@@ -175,6 +194,7 @@ fn nix_and_cmake_files_use_code_preview_support() {
 #[test]
 fn make_and_c_files_get_targeted_preview_support() {
     let makefile = inspect_path(Path::new("Makefile"), EntryKind::File);
+    let makefile_template = inspect_path(Path::new("Makefile.in"), EntryKind::File);
     let c_source = inspect_path(Path::new("main.c"), EntryKind::File);
     let c_header = inspect_path(Path::new("app.h"), EntryKind::File);
 
@@ -182,6 +202,18 @@ fn make_and_c_files_get_targeted_preview_support() {
     assert_eq!(makefile.specific_type_label, Some("Makefile"));
     assert_eq!(makefile.preview.language_hint, Some("make"));
     assert_code_spec(makefile.preview, Some("make"), CodeBackend::Syntect);
+
+    assert_eq!(makefile_template.builtin_class, FileClass::Config);
+    assert_eq!(
+        makefile_template.specific_type_label,
+        Some("Makefile template")
+    );
+    assert_eq!(makefile_template.preview.language_hint, Some("make"));
+    assert_code_spec(
+        makefile_template.preview,
+        Some("make"),
+        CodeBackend::Syntect,
+    );
 
     assert_eq!(c_source.builtin_class, FileClass::Code);
     assert_eq!(c_source.specific_type_label, Some("C source file"));
@@ -214,6 +246,7 @@ fn js_like_files_use_syntax_highlighting() {
 fn curated_generic_languages_use_syntect_preview_support() {
     let sql = inspect_path(Path::new("schema.sql"), EntryKind::File);
     let diff = inspect_path(Path::new("changes.diff"), EntryKind::File);
+    let cocci = inspect_path(Path::new("andand.cocci"), EntryKind::File);
     let dockerfile = inspect_path(Path::new("Dockerfile"), EntryKind::File);
     let groovy = inspect_path(Path::new("build.gradle"), EntryKind::File);
     let scala = inspect_path(Path::new("build.sbt"), EntryKind::File);
@@ -249,6 +282,10 @@ fn curated_generic_languages_use_syntect_preview_support() {
     assert_eq!(diff.builtin_class, FileClass::Code);
     assert_eq!(diff.specific_type_label, Some("Diff file"));
     assert_code_spec(diff.preview, Some("diff"), CodeBackend::Syntect);
+
+    assert_eq!(cocci.builtin_class, FileClass::Code);
+    assert_eq!(cocci.specific_type_label, Some("Coccinelle semantic patch"));
+    assert_code_spec(cocci.preview, Some("diff"), CodeBackend::Syntect);
 
     assert_eq!(dockerfile.builtin_class, FileClass::Config);
     assert_eq!(dockerfile.specific_type_label, Some("Docker build file"));

--- a/src/file_info/tests/mod.rs
+++ b/src/file_info/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::core::{EntryKind, FileClass};
+use crate::core::{Entry, EntryKind, FileClass};
 use std::{
     fs,
     path::{Path, PathBuf},

--- a/src/file_info/tests/names.rs
+++ b/src/file_info/tests/names.rs
@@ -102,6 +102,25 @@ fn shell_files_and_dotfiles_get_targeted_preview_support() {
 }
 
 #[test]
+fn kyua_files_and_templates_use_lua_preview_support() {
+    let kyua = inspect_path(Path::new("Kyuafile"), EntryKind::File);
+    let kyua_template = inspect_path(Path::new("Kyuafile.in"), EntryKind::File);
+
+    assert_eq!(kyua.builtin_class, FileClass::Config);
+    assert_eq!(kyua.specific_type_label, Some("Kyua test config"));
+    assert_eq!(kyua.preview.language_hint, Some("lua"));
+    assert_code_spec(kyua.preview, Some("lua"), CodeBackend::Syntect);
+
+    assert_eq!(kyua_template.builtin_class, FileClass::Config);
+    assert_eq!(
+        kyua_template.specific_type_label,
+        Some("Kyua test config template")
+    );
+    assert_eq!(kyua_template.preview.language_hint, Some("lua"));
+    assert_code_spec(kyua_template.preview, Some("lua"), CodeBackend::Syntect);
+}
+
+#[test]
 fn shebang_and_exact_name_detection_cover_new_languages() {
     let (perl_root, perl_path) = write_temp_file(
         "extensionless-perl-script",

--- a/src/preview/code/backends/syntect/semantics.rs
+++ b/src/preview/code/backends/syntect/semantics.rs
@@ -33,6 +33,10 @@ struct ScopeSelectors {
     macro_name: [Scope; 4],
     invalid: [Scope; 2],
     variable_readwrite: [Scope; 1],
+    diff_inserted: [Scope; 1],
+    diff_deleted: [Scope; 1],
+    diff_changed: [Scope; 1],
+    diff_header: [Scope; 2],
     shell_source: [Scope; 1],
     shell_function_call: [Scope; 1],
     shell_function_arguments: [Scope; 1],
@@ -41,7 +45,15 @@ struct ScopeSelectors {
 pub(super) fn semantic_role_for_token(text: &str, scope_stack: &[Scope]) -> SemanticRole {
     let selectors = scope_selectors();
 
-    if scope_stack_matches(scope_stack, &selectors.invalid) {
+    if scope_stack_matches(scope_stack, &selectors.diff_inserted) {
+        SemanticRole::String
+    } else if scope_stack_matches(scope_stack, &selectors.diff_deleted) {
+        SemanticRole::Invalid
+    } else if scope_stack_matches(scope_stack, &selectors.diff_changed) {
+        SemanticRole::Keyword
+    } else if scope_stack_matches(scope_stack, &selectors.diff_header) {
+        SemanticRole::Comment
+    } else if scope_stack_matches(scope_stack, &selectors.invalid) {
         SemanticRole::Invalid
     } else if scope_stack_matches(scope_stack, &selectors.comment) {
         SemanticRole::Comment
@@ -152,6 +164,10 @@ fn scope_selectors() -> &'static ScopeSelectors {
             ],
             invalid: [scope("invalid"), scope("invalid.deprecated")],
             variable_readwrite: [scope("variable.other.readwrite")],
+            diff_inserted: [scope("markup.inserted")],
+            diff_deleted: [scope("markup.deleted")],
+            diff_changed: [scope("markup.changed")],
+            diff_header: [scope("meta.diff"), scope("meta.diff.header")],
             shell_source: [scope("source.shell")],
             shell_function_call: [scope("meta.function-call")],
             shell_function_arguments: [scope("meta.function-call.arguments")],

--- a/src/preview/code/backends/syntect/tests.rs
+++ b/src/preview/code/backends/syntect/tests.rs
@@ -410,6 +410,27 @@ fn sh_tokens_map_to_semantic_roles() {
 }
 
 #[test]
+fn diff_tokens_map_to_theme_palette_roles() {
+    let tokens = token_scopes(
+        "diff",
+        "diff --git a/file b/file\n@@ -1 +1 @@\n-old\n+new\n",
+    );
+
+    let role_for = |needle: &str| {
+        let (_token, scopes) = tokens
+            .iter()
+            .find(|(token, _scopes)| token.contains(needle))
+            .unwrap_or_else(|| panic!("expected token containing {needle}"));
+        let stack = ScopeStack::from_str(scopes).expect("scope stack should parse");
+        semantic_role_for_token(needle, stack.as_slice())
+    };
+
+    assert_eq!(role_for("@@"), SemanticRole::Comment);
+    assert_eq!(role_for("old"), SemanticRole::Invalid);
+    assert_eq!(role_for("new"), SemanticRole::String);
+}
+
+#[test]
 fn bash_tokens_map_to_semantic_roles() {
     let palette = theme::code_preview_palette();
     let sample = "NAME=elio\nif [ -n \"$HOME\" ]; then\n  echo \"$NAME\"\nfi # done\n";

--- a/src/preview/code/registry/data/languages.rs
+++ b/src/preview/code/registry/data/languages.rs
@@ -173,7 +173,7 @@ pub(super) const LANGUAGES: &[RegistryEntry] = &[
     entry(
         language("lua", "Lua", CodeBackend::Syntect, None),
         &["lua"],
-        &[],
+        &["kyuafile"],
         &[],
         &["lua"],
         &["lua"],

--- a/src/preview/code/registry/tests.rs
+++ b/src/preview/code/registry/tests.rs
@@ -117,6 +117,10 @@ fn exact_name_lookup_handles_lockfiles_and_env_variants() {
         Some("just")
     );
     assert_eq!(
+        language_for_exact_name("Kyuafile").map(|language| language.canonical_id),
+        Some("lua")
+    );
+    assert_eq!(
         language_for_exact_name("deps.edn").map(|language| language.canonical_id),
         Some("clojure")
     );

--- a/src/preview/tests/code/syntect.rs
+++ b/src/preview/tests/code/syntect.rs
@@ -594,6 +594,16 @@ fn diff_preview_uses_curated_syntect_support() {
         }),
         "expected diff preview to contain at least one highlighted token",
     );
+    assert_eq!(
+        span_color(&preview.lines[6], "fn new() {}"),
+        Some(code_palette.string),
+        "expected added lines to use the themed string color",
+    );
+    assert_eq!(
+        span_color(&preview.lines[5], "fn old() {}"),
+        Some(code_palette.invalid),
+        "expected deleted lines to use the themed invalid color",
+    );
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }

--- a/src/ui/theme/appearance/resolve.rs
+++ b/src/ui/theme/appearance/resolve.rs
@@ -1,7 +1,7 @@
 use super::{
     entry_class_cache,
     rules::normalize_key,
-    types::{EntryClassCacheKey, ResolvedAppearance, Theme},
+    types::{EntryClassCacheKey, ResolvedAppearance, RuleOverride, Theme},
 };
 use crate::{
     app::{Entry, EntryKind, FileClass},
@@ -34,14 +34,34 @@ impl Theme {
             .and_then(|ext| ext.to_str())
             .unwrap_or_default()
             .to_ascii_lowercase();
+        let template_name = (kind == EntryKind::File)
+            .then(|| normalized_name.strip_suffix(".in"))
+            .flatten()
+            .filter(|name| !name.is_empty());
+        let template_ext = template_name
+            .and_then(|name| Path::new(name).extension())
+            .and_then(|ext| ext.to_str())
+            .map(str::to_ascii_lowercase);
 
         let exact_rule = match kind {
             EntryKind::Directory => self.directories.get(&normalized_name),
-            EntryKind::File => self.files.get(&normalized_name),
+            EntryKind::File => self.files.get(&normalized_name).or_else(|| {
+                template_name.and_then(|name| {
+                    self.files
+                        .get(name)
+                        .filter(|rule| is_template_rule_candidate(rule))
+                })
+            }),
         };
         let ext_rule = (kind == EntryKind::File)
             .then(|| self.extensions.get(&ext))
-            .flatten();
+            .flatten()
+            .or_else(|| {
+                template_ext
+                    .as_deref()
+                    .and_then(|ext| self.extensions.get(ext))
+                    .filter(|rule| is_template_rule_candidate(rule))
+            });
         let prefer_builtin_symlink = matches!(
             builtin_class,
             FileClass::SymlinkDirectory | FileClass::BrokenSymlink
@@ -96,6 +116,15 @@ impl Theme {
             color,
         }
     }
+}
+
+fn is_template_rule_candidate(rule: &RuleOverride) -> bool {
+    rule.class.is_none_or(|class| {
+        matches!(
+            class,
+            FileClass::Code | FileClass::Config | FileClass::Document | FileClass::Data
+        )
+    })
 }
 
 pub(super) fn builtin_classify_path(path: &Path, kind: EntryKind) -> FileClass {

--- a/src/ui/theme/appearance/rules/extensions.rs
+++ b/src/ui/theme/appearance/rules/extensions.rs
@@ -46,6 +46,14 @@ pub(super) fn default_extension_rules() -> HashMap<String, RuleOverride> {
             },
         ),
         (
+            "cocci".to_string(),
+            RuleOverride {
+                class: Some(FileClass::Code),
+                icon: Some("".to_string()),
+                color: Some(rgb(140, 184, 255)),
+            },
+        ),
+        (
             "hcl".to_string(),
             RuleOverride {
                 class: Some(FileClass::Config),
@@ -642,6 +650,12 @@ pub(super) fn default_extension_rules() -> HashMap<String, RuleOverride> {
         ("md5".to_string(), rule_class(FileClass::Data)),
         ("log".to_string(), rule_class(FileClass::Document)),
         ("srt".to_string(), rule_class(FileClass::Document)),
+        ("vtt".to_string(), rule_class(FileClass::Document)),
+        ("ass".to_string(), rule_class(FileClass::Document)),
+        ("ssa".to_string(), rule_class(FileClass::Document)),
+        ("ttml".to_string(), rule_class(FileClass::Document)),
+        ("sbv".to_string(), rule_class(FileClass::Document)),
+        ("smi".to_string(), rule_class(FileClass::Document)),
         ("keys".to_string(), rule_class(FileClass::Config)),
         ("p12".to_string(), rule_class(FileClass::Config)),
         ("pfx".to_string(), rule_class(FileClass::Config)),

--- a/src/ui/theme/appearance/rules/files.rs
+++ b/src/ui/theme/appearance/rules/files.rs
@@ -278,6 +278,14 @@ pub(super) fn default_file_rules() -> HashMap<String, RuleOverride> {
             },
         ),
         (
+            normalize_key(".gitkeep"),
+            RuleOverride {
+                class: Some(FileClass::Config),
+                icon: Some("󰊢".to_string()),
+                color: Some(rgb(232, 153, 88)),
+            },
+        ),
+        (
             normalize_key(".env"),
             RuleOverride {
                 class: Some(FileClass::Config),
@@ -291,6 +299,30 @@ pub(super) fn default_file_rules() -> HashMap<String, RuleOverride> {
                 class: Some(FileClass::Config),
                 icon: Some("".to_string()),
                 color: Some(rgb(102, 187, 255)),
+            },
+        ),
+        (
+            normalize_key("GNUmakefile"),
+            RuleOverride {
+                class: Some(FileClass::Config),
+                icon: Some("".to_string()),
+                color: Some(rgb(255, 155, 97)),
+            },
+        ),
+        (
+            normalize_key("BSDmakefile"),
+            RuleOverride {
+                class: Some(FileClass::Config),
+                icon: Some("".to_string()),
+                color: Some(rgb(255, 155, 97)),
+            },
+        ),
+        (
+            normalize_key("Kyuafile"),
+            RuleOverride {
+                class: Some(FileClass::Config),
+                icon: Some("".to_string()),
+                color: Some(rgb(122, 174, 255)),
             },
         ),
     ])

--- a/src/ui/theme/appearance/tests/builtin.rs
+++ b/src/ui/theme/appearance/tests/builtin.rs
@@ -86,6 +86,7 @@ fn built_in_default_theme_asset_matches_runtime_default_theme() {
         ("Cargo.toml", EntryKind::File),
         ("Cargo.lock", EntryKind::File),
         ("README.md", EntryKind::File),
+        (".gitkeep", EntryKind::File),
         ("main.rs", EntryKind::File),
     ] {
         let built_in = built_in_asset.resolve(Path::new(path), kind);
@@ -132,6 +133,21 @@ fn default_theme_assigns_specific_icons_for_common_dev_paths() {
     assert_eq!(notebook.icon, "");
     assert_eq!(notebook.color, rgb(255, 184, 107));
 
+    for path in [
+        "movie.srt",
+        "movie.vtt",
+        "movie.ass",
+        "movie.ssa",
+        "movie.ttml",
+        "movie.sbv",
+        "movie.smi",
+    ] {
+        let subtitles = theme.resolve(Path::new(path), EntryKind::File);
+        assert_eq!(subtitles.class, FileClass::Document, "{path}");
+        assert_eq!(subtitles.icon, "󰨖", "{path}");
+        assert_eq!(subtitles.color, rgb(111, 102, 255), "{path}");
+    }
+
     for path in ["main.o", "main.obj"] {
         let object = theme.resolve(Path::new(path), EntryKind::File);
         assert_eq!(object.class, FileClass::File, "{path}");
@@ -159,6 +175,46 @@ fn default_theme_assigns_specific_icons_for_common_dev_paths() {
 
     let package = theme.resolve(Path::new("package.json"), EntryKind::File);
     assert_eq!(package.icon, "󰏗");
+
+    for path in [
+        "Makefile",
+        "GNUmakefile",
+        "BSDmakefile",
+        "Makefile.in",
+        "GNUmakefile.in",
+        "BSDmakefile.in",
+    ] {
+        let makefile = theme.resolve(Path::new(path), EntryKind::File);
+        assert_eq!(makefile.class, FileClass::Config, "{path}");
+        assert_eq!(makefile.icon, "", "{path}");
+        assert_eq!(makefile.color, rgb(255, 155, 97), "{path}");
+    }
+
+    let kyua_template = theme.resolve(Path::new("Kyuafile.in"), EntryKind::File);
+    assert_eq!(kyua_template.class, FileClass::Config);
+    assert_eq!(kyua_template.icon, "");
+    assert_eq!(kyua_template.color, rgb(122, 174, 255));
+
+    let bash_template = theme.resolve(Path::new("_pkg.bash.in"), EntryKind::File);
+    assert_eq!(bash_template.class, FileClass::Code);
+    assert_eq!(bash_template.icon, "");
+    assert_eq!(bash_template.color, rgb(214, 222, 240));
+
+    let unknown_template = theme.resolve(Path::new("1.in"), EntryKind::File);
+    assert_eq!(unknown_template.class, FileClass::File);
+
+    let binary_name_template = theme.resolve(Path::new("logo.png.in"), EntryKind::File);
+    assert_eq!(binary_name_template.class, FileClass::File);
+
+    let gitkeep = theme.resolve(Path::new(".gitkeep"), EntryKind::File);
+    assert_eq!(gitkeep.class, FileClass::Config);
+    assert_eq!(gitkeep.icon, "󰊢");
+    assert_eq!(gitkeep.color, rgb(215, 142, 255));
+
+    let cocci = theme.resolve(Path::new("andand.cocci"), EntryKind::File);
+    assert_eq!(cocci.class, FileClass::Code);
+    assert_eq!(cocci.icon, "");
+    assert_eq!(cocci.color, rgb(140, 184, 255));
 
     for path in ["angular.json", "ng-package.json"] {
         let angular = theme.resolve(Path::new(path), EntryKind::File);
@@ -189,6 +245,11 @@ fn default_theme_assigns_specific_icons_for_common_dev_paths() {
     assert_eq!(bin.class, FileClass::Directory);
     assert_eq!(bin.icon, "󱁿");
     assert_eq!(bin.color, rgb(91, 168, 255));
+
+    let config = theme.resolve(Path::new("config"), EntryKind::Directory);
+    assert_eq!(config.class, FileClass::Directory);
+    assert_eq!(config.icon, "󱁿");
+    assert_eq!(config.color, rgb(91, 168, 255));
 
     let lib = theme.resolve(Path::new("lib"), EntryKind::Directory);
     assert_eq!(lib.class, FileClass::Directory);

--- a/src/ui/theme/appearance/tests/classification.rs
+++ b/src/ui/theme/appearance/tests/classification.rs
@@ -360,6 +360,36 @@ fn resolve_browser_entry_preserves_non_canonical_spdx_license_appearance() {
 }
 
 #[test]
+fn resolve_browser_entry_keeps_spdx_shebang_scripts_as_code() {
+    let (root, path) = write_temp_file(
+        "browser-spdx-shell-script",
+        "configure",
+        "#!/bin/sh\n\n# SPDX-License-Identifier: ISC\n#\n# configure - POSIX shell build configuration framework\n\nset -e\n",
+    );
+
+    let metadata = fs::metadata(&path).expect("metadata should exist");
+    let entry = Entry {
+        path: path.clone(),
+        name: "configure".to_string(),
+        name_key: "configure".to_string(),
+        kind: EntryKind::File,
+        symlink: None,
+        size: metadata.len(),
+        modified: metadata.modified().ok(),
+        readonly: false,
+    };
+
+    let browser = resolve_browser_entry(&entry);
+    let preview = resolve_entry(&entry);
+
+    assert_eq!(browser.class, FileClass::Code);
+    assert_eq!(preview.class, FileClass::Code);
+    assert_ne!(browser.icon, "󰿃");
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn resolve_browser_entry_preserves_standalone_license_text_without_canonical_filename() {
     let (root, path) = write_temp_file(
         "browser-standalone-license",
@@ -430,10 +460,21 @@ fn type_labels_cover_supported_special_files() {
         specific_type_label(Path::new("server.log"), EntryKind::File),
         Some("Log file")
     );
-    assert_eq!(
-        specific_type_label(Path::new("movie.srt"), EntryKind::File),
-        Some("SubRip subtitles")
-    );
+    for (path, label) in [
+        ("movie.srt", "SubRip subtitles"),
+        ("movie.vtt", "WebVTT subtitles"),
+        ("movie.ass", "ASS subtitles"),
+        ("movie.ssa", "SubStation Alpha subtitles"),
+        ("movie.ttml", "TTML subtitles"),
+        ("movie.sbv", "SBV subtitles"),
+        ("movie.smi", "SAMI subtitles"),
+    ] {
+        assert_eq!(
+            specific_type_label(Path::new(path), EntryKind::File),
+            Some(label),
+            "{path}"
+        );
+    }
     assert_eq!(
         specific_type_label(Path::new("bindings.keys"), EntryKind::File),
         Some("Keys file")
@@ -602,10 +643,21 @@ fn builtin_classification_covers_new_special_file_types() {
         builtin_classify_path(Path::new("server.log"), EntryKind::File),
         FileClass::Document
     );
-    assert_eq!(
-        builtin_classify_path(Path::new("movie.srt"), EntryKind::File),
-        FileClass::Document
-    );
+    for path in [
+        "movie.srt",
+        "movie.vtt",
+        "movie.ass",
+        "movie.ssa",
+        "movie.ttml",
+        "movie.sbv",
+        "movie.smi",
+    ] {
+        assert_eq!(
+            builtin_classify_path(Path::new(path), EntryKind::File),
+            FileClass::Document,
+            "{path}"
+        );
+    }
     assert_eq!(
         builtin_classify_path(Path::new("bindings.keys"), EntryKind::File),
         FileClass::Config

--- a/src/ui/theme/appearance/tests/examples.rs
+++ b/src/ui/theme/appearance/tests/examples.rs
@@ -1,5 +1,6 @@
 use super::super::rules::rgb;
 use super::*;
+use ratatui::style::Color;
 
 const ALTERNATE_EXAMPLE_THEME_NAMES: &[&str] = &[
     "default-light",
@@ -100,6 +101,36 @@ fn alternate_example_themes_style_symlinks_like_their_base_kinds() {
     for name in ALTERNATE_EXAMPLE_THEME_NAMES {
         let theme = load_alternate_example_theme(name);
         assert_symlink_directory_matches_folder_color(&theme, name);
+    }
+}
+
+#[test]
+fn alternate_example_themes_use_theme_native_subtitle_colors() {
+    for (name, expected_color) in [
+        ("default-light", rgb(0x71, 0x68, 0xd9)),
+        ("blush-light", rgb(0xa0, 0x8d, 0xd1)),
+        ("amber-dusk", rgb(0xaf, 0x89, 0xbf)),
+        ("catppuccin-mocha", rgb(0xb4, 0xbe, 0xfe)),
+        ("tokyo-night", rgb(0x9d, 0x7c, 0xd8)),
+        ("terminal-ansi", Color::Magenta),
+    ] {
+        let theme = load_alternate_example_theme(name);
+
+        for path in [
+            "movie.srt",
+            "movie.vtt",
+            "movie.ass",
+            "movie.ssa",
+            "movie.ttml",
+            "movie.sbv",
+            "movie.smi",
+        ] {
+            let subtitles = theme.resolve(Path::new(path), EntryKind::File);
+
+            assert_eq!(subtitles.class, FileClass::Document, "{name}: {path}");
+            assert_eq!(subtitles.icon, "󰨖", "{name}: {path}");
+            assert_eq!(subtitles.color, expected_color, "{name}: {path}");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Improve file type detection and themed icons for several edge-case file types.

Common subtitle formats now get subtitle-specific labels and icons. Coccinelle `.cocci` semantic patches are detected as code and use diff-style previews. Default and example themes also get better icons for `.gitkeep`, Makefile variants, `Kyuafile`, `config` directories, subtitle files, and diff/patch previews.

`.in` templates such as `Makefile.in`, `Kyuafile.in`, and shell completion templates now inherit the underlying file type behavior where appropriate, while unknown or binary-named templates stay plain. Extensionless shell scripts with SPDX headers keep code icons instead of being shown as license files.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed