### PR TITLE
fix(test): stabilize Windows cleanup

### DIFF
--- a/src/app/create/editor_bulk_rename.rs
+++ b/src/app/create/editor_bulk_rename.rs
@@ -1,16 +1,19 @@
+#[cfg(unix)]
+use super::super::state::{BulkRenameEditorSession, EditorRenameConfirmOverlay};
 use super::super::{
     App,
-    state::{
-        BulkRenameEditorSession, BulkRenameItem, DirectoryHistoryMode, DirectoryLoadCompletion,
-        EditorRenameConfirmOverlay, PendingDirectoryLoad,
-    },
+    state::{BulkRenameItem, DirectoryHistoryMode, DirectoryLoadCompletion, PendingDirectoryLoad},
 };
 use crate::fs::rect_contains;
-use anyhow::{Context, Result, bail};
+#[cfg(unix)]
+use anyhow::Context;
+use anyhow::{Result, bail};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+#[cfg(unix)]
+use std::env;
 use std::{
     collections::HashSet,
-    env, fs,
+    fs,
     path::{Component, Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -72,6 +75,7 @@ impl App {
         Ok(())
     }
 
+    #[cfg(unix)]
     pub(crate) fn finish_editor_bulk_rename(
         &mut self,
         session: BulkRenameEditorSession,
@@ -157,6 +161,7 @@ impl App {
         result
     }
 
+    #[cfg(unix)]
     fn editor_bulk_rename_targets(&self) -> Vec<PathBuf> {
         if !self.navigation.selected_paths.is_empty() {
             return self.selected_paths_in_selection_order();
@@ -166,6 +171,7 @@ impl App {
             .unwrap_or_default()
     }
 
+    #[cfg(unix)]
     fn close_transient_overlays(&mut self) {
         self.overlays.help = false;
         self.overlays.search = None;
@@ -678,6 +684,7 @@ fn display_label(item: &BulkRenameItem, root: Option<&Path>) -> String {
         .into_owned()
 }
 
+#[cfg(unix)]
 fn bulk_rename_item_from_path(path: PathBuf) -> BulkRenameItem {
     let original_name = path_name(&path);
     let is_dir = path.is_dir();
@@ -701,6 +708,7 @@ fn renamed_path(path: &Path, new_name: &str) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(new_name))
 }
 
+#[cfg(any(test, unix))]
 fn common_root(paths: &[PathBuf]) -> PathBuf {
     let mut components: Vec<_> = paths
         .first()
@@ -732,6 +740,7 @@ fn common_root(paths: &[PathBuf]) -> PathBuf {
     }
 }
 
+#[cfg(unix)]
 fn create_temp_file(rows: &[String]) -> Result<PathBuf> {
     let base = env::temp_dir();
     for attempt in 0..1000u32 {
@@ -761,6 +770,7 @@ fn create_temp_file(rows: &[String]) -> Result<PathBuf> {
     bail!("Could not create temporary rename file")
 }
 
+#[cfg(unix)]
 fn editor_command() -> (String, Vec<String>) {
     for key in ["VISUAL", "EDITOR"] {
         if let Some(value) = env::var_os(key).and_then(|value| value.into_string().ok()) {
@@ -773,6 +783,7 @@ fn editor_command() -> (String, Vec<String>) {
     ("vi".to_string(), Vec::new())
 }
 
+#[cfg(unix)]
 fn split_program_args(tokens: Vec<String>) -> Option<(String, Vec<String>)> {
     let mut tokens = tokens.into_iter();
     let program = tokens.next()?;

--- a/src/app/create/tests.rs
+++ b/src/app/create/tests.rs
@@ -1,9 +1,8 @@
+#[cfg(unix)]
+use super::super::state::{BulkRenameEditorSession, PendingTerminalTask};
 use super::super::{
     App,
-    state::{
-        BulkRenameEditorSession, BulkRenameItem, BulkRenameOverlay, DirectoryLoadCompletion,
-        PendingTerminalTask,
-    },
+    state::{BulkRenameItem, BulkRenameOverlay, DirectoryLoadCompletion},
 };
 use super::rename;
 #[cfg(unix)]

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -2,8 +2,8 @@ use super::super::*;
 #[cfg(all(unix, not(target_os = "macos")))]
 use super::helpers::read_open_capture;
 use super::helpers::{
-    OpenInSystemCaptureGuard, temp_path, wait_for_background_preview, wait_for_directory_load,
-    write_epub_fixture,
+    OpenInSystemCaptureGuard, cleanup_app_temp_root, temp_path, wait_for_background_preview,
+    wait_for_directory_load, write_epub_fixture,
 };
 use crate::config::Action;
 use std::{
@@ -1119,7 +1119,7 @@ fn tab_and_shift_tab_cycle_sidebar_locations_and_skip_section_rows() {
     wait_for_directory_load(&mut app);
     assert_eq!(app.navigation.cwd, downloads);
 
-    fs::remove_dir_all(root).expect("failed to remove temp root");
+    cleanup_app_temp_root(app, root);
 }
 
 #[cfg(unix)]
@@ -1193,7 +1193,7 @@ fn tab_and_shift_tab_match_symlinked_sidebar_locations_by_identity() {
     wait_for_directory_load(&mut app);
     assert_eq!(app.navigation.cwd, target_identity);
 
-    fs::remove_dir_all(root).expect("failed to remove temp root");
+    cleanup_app_temp_root(app, root);
 }
 
 #[test]

--- a/src/app/selection/mod.rs
+++ b/src/app/selection/mod.rs
@@ -16,6 +16,7 @@ impl App {
         paths
     }
 
+    #[cfg(unix)]
     pub(in crate::app) fn selected_paths_in_selection_order(&self) -> Vec<PathBuf> {
         self.navigation.selected_paths.ordered().cloned().collect()
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -218,6 +218,7 @@ pub(super) struct BulkRenameItem {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg(unix)]
 pub(crate) struct BulkRenameEditorSession {
     pub(crate) root: PathBuf,
     pub(crate) temp_path: PathBuf,
@@ -470,6 +471,7 @@ impl SelectedPaths {
         self.inner.iter()
     }
 
+    #[cfg(unix)]
     pub(in crate::app) fn ordered(&self) -> impl Iterator<Item = &PathBuf> {
         self.order.iter()
     }
@@ -779,6 +781,7 @@ pub(crate) enum PendingTerminalTask {
         args: Vec<String>,
     },
     Commands(Vec<(String, Vec<String>)>),
+    #[cfg(unix)]
     EditorBulkRename {
         program: String,
         args: Vec<String>,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -458,6 +458,7 @@ fn run_app(
                         pause_runtime_input(&input_reader, false);
                         None
                     }
+                    #[cfg(unix)]
                     PendingTerminalTask::EditorBulkRename {
                         program,
                         args,


### PR DESCRIPTION
## Summary

Drop app directory watchers before cleaning up sidebar navigation test fixtures, avoiding Windows temp directory removal races.

Hide Unix-only editor rename plumbing from non-Unix builds so Windows CI stays warning-free.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`