### PR TITLE
config(macos): support ~/.config/elio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made create and bulk rename overlays show more rows before scrolling, adapt better on short terminals, and use consistent scrollbar styling.
 - Dimmed help overlay key separators (`/`) and removed the bottom close hint.
 - Improved default and example theme icons for `.gitkeep`, Makefile variants, `Kyuafile`, `config` directories, subtitle files, and diff/patch previews.
+- Support `~/.config/elio` for config and theme files on macOS. ([#240])
 
 ### Fixed
 
@@ -288,6 +289,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/elio-fm/elio/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/elio-fm/elio/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/elio-fm/elio/releases/tag/v1.0.0
+[#240]: https://github.com/elio-fm/elio/issues/240
 [#235]: https://github.com/elio-fm/elio/issues/235
 [#232]: https://github.com/elio-fm/elio/issues/232
 [#223]: https://github.com/elio-fm/elio/issues/223

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ elio reads configuration from:
 | Platform | Config file |
 |---|---|
 | Linux / BSD | `~/.config/elio/config.toml` or `$XDG_CONFIG_HOME/elio/config.toml` |
-| macOS | `~/Library/Application Support/elio/config.toml` |
+| macOS | `~/.config/elio/config.toml` or `~/Library/Application Support/elio/config.toml` |
 | Windows | `%APPDATA%\elio\config.toml` |
 
 See [`examples/config.toml`](examples/config.toml) for an annotated example, or the configuration docs:
@@ -243,7 +243,7 @@ elio themes are TOML files layered on top of the built-in defaults, so you only 
 | Platform | Theme file |
 |---|---|
 | Linux / BSD | `~/.config/elio/theme.toml` or `$XDG_CONFIG_HOME/elio/theme.toml` |
-| macOS | `~/Library/Application Support/elio/theme.toml` |
+| macOS | `~/.config/elio/theme.toml` or `~/Library/Application Support/elio/theme.toml` |
 | Windows | `%APPDATA%\elio\theme.toml` |
 
 See [`assets/themes/default/theme.toml`](assets/themes/default/theme.toml) for the full default theme and [`examples/themes/`](examples/themes/) for ready-made themes.

--- a/src/app/actions/goto.rs
+++ b/src/app/actions/goto.rs
@@ -234,14 +234,13 @@ fn downloads_destination(app: &App) -> Option<PathBuf> {
         .filter(|path| path.exists())
 }
 
-/// Returns the platform config home — one level above elio's own config dir.
+/// Returns the platform config home.
 ///
 /// - Linux / BSD: `~/.config` (or `$XDG_CONFIG_HOME`)
 /// - macOS: `~/Library/Application Support`
 /// - Windows: `%APPDATA%`
 fn config_directory() -> Option<PathBuf> {
-    let dir = crate::config::config_dir()?;
-    dir.parent().map(PathBuf::from)
+    dirs::config_dir()
 }
 
 fn trash_destination(app: &App) -> Option<PathBuf> {

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -18,6 +18,19 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
         return Some(PathBuf::from(config_home).join("elio"));
     }
 
+    #[cfg(target_os = "macos")]
+    {
+        // Prefer XDG-style config on macOS only when it contains Elio config
+        // files, avoiding empty ~/.config/elio directories shadowing the native
+        // Application Support location.
+        if let Some(home) = dirs::home_dir() {
+            let xdg_dir = home.join(".config/elio");
+            if xdg_dir.join("config.toml").is_file() || xdg_dir.join("theme.toml").is_file() {
+                return Some(xdg_dir);
+            }
+        }
+    }
+
     // dirs::config_dir() returns:
     //   Linux/BSD : $HOME/.config
     //   macOS     : $HOME/Library/Application Support


### PR DESCRIPTION
## Summary

Support loading macOS config and theme files from `~/.config/elio`.

If `~/.config/elio` contains `config.toml` or `theme.toml`, elio uses it as the active config directory. Otherwise, macOS keeps using `~/Library/Application Support/elio`.

Closes #240.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested on macOS that `~/.config/elio` is used when it contains `config.toml` or `theme.toml`.
- Tested that an empty `~/.config/elio` does not shadow `~/Library/Application Support/elio`.
- Tested that Go To config still opens the macOS system config folder.

## Documentation and Changelog

- [x] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed