### PR TITLE
fix(clipboard): handle tmux OSC52 restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Fuzzy Find result icons for nested files that use full-name rules, such as `LICENSE.md`.
 - Fixed `.in` templates such as `Makefile.in`, `Kyuafile.in`, and shell completion templates being shown as plain files.
 - Fixed extensionless shell scripts with SPDX headers being shown as license files.
+- Fixed Copy to clipboard inside tmux when tmux blocks OSC52 clipboard escape sequences.
 
 ## [1.10.0] - 2026-06-30
 

--- a/src/app/clipboard/copy.rs
+++ b/src/app/clipboard/copy.rs
@@ -347,12 +347,16 @@ fn build_osc52_set_clipboard_sequence(text: &str) -> String {
 }
 
 fn terminal_supports_osc52_clipboard() -> bool {
-    #[cfg(test)]
-    if env::var_os("ELIO_TEST_OSC52_CAPTURE").is_some() {
+    if env::var_os("ELIO_CLIPBOARD_OSC52").is_some() {
         return true;
     }
 
-    if env::var_os("ELIO_CLIPBOARD_OSC52").is_some() {
+    if env::var_os("TMUX").is_some() && !tmux_accepts_application_osc52() {
+        return false;
+    }
+
+    #[cfg(test)]
+    if env::var_os("ELIO_TEST_OSC52_CAPTURE").is_some() {
         return true;
     }
 
@@ -378,6 +382,21 @@ fn terminal_supports_osc52_clipboard() -> bool {
         || env::var_os("ALACRITTY_SOCKET").is_some()
         || env::var_os("VTE_VERSION").is_some()
         || env::var_os("WT_SESSION").is_some()
+}
+
+fn tmux_accepts_application_osc52() -> bool {
+    #[cfg(test)]
+    if let Some(value) = env::var_os("ELIO_TEST_TMUX_SET_CLIPBOARD") {
+        return value.to_string_lossy().trim().eq_ignore_ascii_case("on");
+    }
+
+    Command::new("tmux")
+        .args(["show-options", "-gqv", "set-clipboard"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("on"))
 }
 
 fn run_clipboard_command(program: &str, args: &[String], text: &str) -> Result<()> {

--- a/src/app/clipboard/tests.rs
+++ b/src/app/clipboard/tests.rs
@@ -71,7 +71,9 @@ impl ClipboardEnvGuard {
         const VARS: &[&str] = &[
             "ELIO_TEST_CLIPBOARD_TOOL",
             "ELIO_TEST_OSC52_CAPTURE",
+            "ELIO_TEST_TMUX_SET_CLIPBOARD",
             "ELIO_CLIPBOARD_OSC52",
+            "TMUX",
             "TERM",
             "TERM_PROGRAM",
             "KITTY_WINDOW_ID",
@@ -1085,6 +1087,48 @@ fn copy_overlay_shortcut_uses_osc52_override_for_unknown_terminals() {
         !app.copy_is_open(),
         "successful copy should close the overlay"
     );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[cfg(unix)]
+#[test]
+fn copy_overlay_skips_osc52_in_tmux_when_tmux_rejects_application_clipboard() {
+    let _lock = clipboard_env_lock();
+    let _env = ClipboardEnvGuard::isolate();
+    let root = temp_path("copy-overlay-tmux-external");
+    fs::create_dir_all(root.join("docs")).expect("failed to create docs dir");
+    let file = root.join("docs/report final.md");
+    let capture = root.join("clipboard.txt");
+    let osc52_capture = root.join("osc52.txt");
+    fs::write(&file, "notes").expect("failed to write test file");
+    let tool = install_fake_clipboard_tool(&root, &capture);
+
+    unsafe {
+        env::set_var("ELIO_TEST_CLIPBOARD_TOOL", &tool);
+        env::set_var("ELIO_TEST_OSC52_CAPTURE", &osc52_capture);
+        env::set_var("ELIO_TEST_TMUX_SET_CLIPBOARD", "external");
+        env::set_var("TMUX", "/tmp/tmux-test,1,0");
+        env::set_var("TERM", "xterm-kitty");
+        env::set_var("KITTY_WINDOW_ID", "1");
+    }
+
+    let mut app = App::new_at(root.join("docs")).expect("failed to create app");
+    app.open_copy_overlay();
+    app.handle_copy_key(crossterm::event::KeyEvent::from(
+        crossterm::event::KeyCode::Char('p'),
+    ))
+    .expect("copy shortcut should succeed");
+
+    assert!(
+        !osc52_capture.exists(),
+        "tmux set-clipboard=external should prevent application OSC52 writes"
+    );
+    assert_eq!(
+        fs::read_to_string(&capture).expect("fake clipboard tool should capture text"),
+        file.display().to_string()
+    );
+    assert_eq!(app.status, "Copied file path");
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }


### PR DESCRIPTION
## Summary

Fix Copy to clipboard inside tmux when tmux blocks application OSC52 clipboard writes.

Before using OSC52 inside tmux, the active tmux clipboard policy is checked. When application clipboard writes are not allowed, Copy to clipboard falls back to system clipboard helpers instead of reporting success without changing the clipboard.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

Manual checks:

- Tested Copy to clipboard inside tmux on Kitty, Konsole, and Alacritty.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed