### PR TITLE
chore(release): prepare v1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-07-18
+
+### Changed
+
+- Switched syntax highlighting to syntect's pure-Rust regex backend, removing the native Oniguruma dependency.
+
 ## [1.11.0] - 2026-07-18
 
 ### Added
@@ -279,7 +285,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Trash and restore support for safer file management workflows.
 - Optional external-tool integrations such as Poppler, ffmpeg, ffprobe, resvg, and 7-Zip for richer previews and metadata.
 
-[Unreleased]: https://github.com/elio-fm/elio/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/elio-fm/elio/compare/v1.11.1...HEAD
+[1.11.1]: https://github.com/elio-fm/elio/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/elio-fm/elio/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/elio-fm/elio/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/elio-fm/elio/compare/v1.8.0...v1.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +78,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -441,7 +465,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -471,7 +495,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elio"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -520,7 +544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -534,6 +558,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fast-srgb8"
@@ -1243,28 +1278,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "onig"
-version = "6.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
-dependencies = [
- "bitflags 2.13.0",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +1562,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,7 +1622,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1842,10 +1866,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
+ "fancy-regex",
  "flate2",
  "fnv",
  "once_cell",
- "onig",
  "regex-syntax",
  "serde",
  "serde_derive",
@@ -2165,7 +2189,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elio"
-version = "1.11.0"
+version = "1.11.1"
 edition = "2024"
 rust-version = "1.95"
 description = "Snappy, batteries-included terminal file manager with rich previews, inline images, bulk actions, and trash support."
@@ -29,7 +29,7 @@ quick-xml = "0.40"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm", "crossterm_0_29"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-syntect = { version = "5.2", default-features = false, features = ["parsing", "regex-onig"] }
+syntect = { version = "5.3", default-features = false, features = ["parsing", "regex-fancy"] }
 tar = "0.4"
 yaml_serde = "0.10"
 toml = "1.1"
@@ -47,7 +47,7 @@ sevenz-rust2 = { version = "0.21.1", default-features = false, features = ["aes2
 sevenz-rust2 = { version = "0.21.1", default-features = false, features = ["aes256", "compress"] }
 
 [build-dependencies]
-syntect = { version = "5.2", default-features = false, features = ["default-syntaxes", "yaml-load", "regex-onig"] }
+syntect = { version = "5.3", default-features = false, features = ["default-syntaxes", "yaml-load", "regex-fancy"] }
 
 [profile.release]
 strip = true

--- a/packaging/fedora/elio.spec
+++ b/packaging/fedora/elio.spec
@@ -1,5 +1,5 @@
 %bcond_with check
-%global fallback_version 1.11.0
+%global fallback_version 1.11.1
 %global fallback_release 1
 
 Name:           elio
@@ -53,6 +53,9 @@ desktop-file-validate packaging/linux/%{name}.desktop
 %{_datadir}/icons/hicolor/*/apps/%{name}.png
 
 %changelog
+* Sat Jul 18 2026 Miguel Regueiro <miguelpr4242@gmail.com> - 1.11.1-1
+- Switch syntax highlighting to the pure-Rust regex backend and remove the native Oniguruma dependency
+
 * Sat Jul 18 2026 Miguel Regueiro <miguelpr4242@gmail.com> - 1.11.0-1
 - Add archive creation for zip, 7z, and tar variants with password prompts
 - Add Kitty drag-and-drop, configurable open rules, and editor-based rename

--- a/src/app/jobs/results/tests/headers.rs
+++ b/src/app/jobs/results/tests/headers.rs
@@ -226,16 +226,11 @@ fn narrow_code_header_prefers_compact_subtype_and_drops_low_priority_notes() {
 fn byte_truncated_code_header_upgrades_to_exact_total_lines_after_background_count() {
     let root = temp_path("byte-truncated-code-header");
     fs::create_dir_all(&root).expect("failed to create temp root");
-    let source = root.join("main.rs");
-    // Lines are ~67 chars: fits 800 within 64 KiB (line cap hits first),
+    let source = root.join("settings.ini");
+    // Lines are ~49 chars: fits 800 within 64 KiB (line cap hits first),
     // but 1500 lines exceed 64 KiB (file is byte-truncated overall).
     let contents = (1..=1_500)
-        .map(|index| {
-            format!(
-                "fn line_{index}() {{ println!(\"{}\"); }}",
-                "word ".repeat(8)
-            )
-        })
+        .map(|index| format!("key_{index}={}", "word ".repeat(8)))
         .collect::<Vec<_>>()
         .join("\n");
     fs::write(&source, contents).expect("failed to write source");
@@ -247,7 +242,7 @@ fn byte_truncated_code_header_upgrades_to_exact_total_lines_after_background_cou
         8,
         40,
         &format!(
-            "Rust • {} / 1,500 lines shown",
+            "INI config • {} / 1,500 lines shown",
             default_code_preview_line_limit()
         ),
     );


### PR DESCRIPTION
## Summary

Prepare v1.11.1.

This switches syntax highlighting to syntect's pure-Rust regex backend, removing the native Oniguruma dependency while keeping preview behavior unchanged in smoke testing.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo build --release`

Manual checks:

- Compared release-run previews for Rust, TS/TSX, JS, Python, shell, TOML, JSON, Markdown fenced code, and large source files.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed