### PR TITLE
fix(browser): avoid 32-bit count overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed 32-bit builds by avoiding `usize` overflow in compact directory count formatting.
+
 ## [1.11.1] - 2026-07-18
 
 ### Changed

--- a/src/ui/browser/entries.rs
+++ b/src/ui/browser/entries.rs
@@ -381,16 +381,17 @@ fn format_compact_directory_count(count: usize, width: usize) -> String {
 }
 
 fn format_compact_directory_quantity(count: usize, width: usize) -> String {
+    let count = count as u64;
     let exact = count.to_string();
     if helpers::display_width(&exact) <= width {
         return exact;
     }
 
     for (divisor, suffix) in [
-        (1_000_000_000_000usize, "T"),
-        (1_000_000_000usize, "B"),
-        (1_000_000usize, "M"),
-        (1_000usize, "K"),
+        (1_000_000_000_000u64, "T"),
+        (1_000_000_000u64, "B"),
+        (1_000_000u64, "M"),
+        (1_000u64, "K"),
     ] {
         if count < divisor {
             continue;


### PR DESCRIPTION
## Summary

Fix compact directory count formatting on 32-bit targets.

The compact count thresholds now use fixed-width `u64` values instead of `usize`, avoiding overflow when building on 32-bit platforms.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed