### PR TITLE
ci: check 32-bit Linux target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ffmpeg \
+            gcc-multilib \
             genisoimage \
             imagemagick \
             libarchive-tools \
@@ -57,6 +58,12 @@ jobs:
 
       - name: cargo fmt --check
         run: cargo fmt --check
+
+      - name: Install i686 Linux target
+        run: rustup target add i686-unknown-linux-gnu
+
+      - name: cargo check --locked --target i686-unknown-linux-gnu
+        run: cargo check --locked --target i686-unknown-linux-gnu
 
       - name: cargo test --locked --test architecture_guardrails
         run: cargo test --locked --test architecture_guardrails


### PR DESCRIPTION
## Summary

Add an Ubuntu CI check for `i686-unknown-linux-gnu`.

This keeps 32-bit compatibility covered by CI.