### PR TITLE
fix(ui): show preview keys consistently in help overlay

### DIFF
--- a/src/config/keys/model.rs
+++ b/src/config/keys/model.rs
@@ -391,13 +391,6 @@ impl KeyList {
         )
     }
 
-    pub(crate) fn single_char(&self) -> Option<char> {
-        match self.0.as_slice() {
-            [spec] => spec.single_char(),
-            _ => None,
-        }
-    }
-
     pub(crate) fn single_chars(&self) -> impl Iterator<Item = char> + '_ {
         self.0
             .iter()

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1443,6 +1443,10 @@ fn help_overlay_keeps_controls_readable_and_drops_auto_reload_row() {
         "expected help overlay to list the vertical preview scroll keys, got: {rendered:?}"
     );
     assert!(
+        rendered.contains("H / L") && !rendered.contains("Shift+H / Shift+L"),
+        "expected help overlay to use standard uppercase notation for horizontal preview scroll keys, got: {rendered:?}"
+    );
+    assert!(
         rendered.contains("View"),
         "expected help overlay to include the View section header, got: {rendered:?}"
     );

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -354,17 +354,7 @@ impl<'a> HelpKeys<'a> {
     fn preview_pair(&self, low: &KeyList, high: &KeyList) -> String {
         let low = self.effective_keys(low);
         let high = self.effective_keys(high);
-        if self.mode.is_chooser() {
-            let low_label = low.to_string();
-            let high_label = high.to_string();
-            match (low_label.is_empty(), high_label.is_empty()) {
-                (true, true) => return String::new(),
-                (true, false) => return high_label,
-                (false, true) => return low_label,
-                (false, false) => {}
-            }
-        }
-        format_preview_scroll_key(&low, &high)
+        format_key_pair(&low, &high)
     }
 
     fn effective_keys(&self, keys: &KeyList) -> KeyList {
@@ -427,20 +417,6 @@ fn format_key_pair(first: &crate::config::KeyList, second: &crate::config::KeyLi
         (first, second) if first.is_empty() => second,
         (first, second) if second.is_empty() => first,
         (first, second) => format!("{first} / {second}"),
-    }
-}
-
-/// Render a preview-scroll key pair: defaults like 'H'/'L' show as "Shift+H / Shift+L";
-/// overrides such as '<'/'>' show as "< / >".
-fn format_preview_scroll_key(
-    low: &crate::config::KeyList,
-    high: &crate::config::KeyList,
-) -> String {
-    match (low.single_char(), high.single_char()) {
-        (Some(low), Some(high)) if low.is_ascii_uppercase() && high.is_ascii_uppercase() => {
-            format!("Shift+{low} / Shift+{high}")
-        }
-        _ => format!("{low} / {high}"),
     }
 }
 
@@ -765,6 +741,34 @@ choose = ["K", "[", "J", "]"]
         assert_eq!(
             keys.preview_pair(&kb.scroll_preview_up, &kb.scroll_preview_down),
             ""
+        );
+    }
+
+    #[test]
+    fn preview_scroll_help_uses_standard_uppercase_notation() {
+        let kb = KeyBindings::default();
+        let keys = HelpKeys::new(&kb, HelpMode::Normal);
+
+        assert_eq!(
+            keys.preview_pair(&kb.scroll_preview_up, &kb.scroll_preview_down),
+            "K/[ / J/]"
+        );
+        assert_eq!(
+            keys.preview_pair(&kb.scroll_preview_left, &kb.scroll_preview_right),
+            "H / L"
+        );
+
+        let kb = KeyBindings::from_toml_str(
+            r#"[keys]
+scroll_preview_left = "A"
+scroll_preview_right = "B"
+"#,
+        );
+        let keys = HelpKeys::new(&kb, HelpMode::Normal);
+
+        assert_eq!(
+            keys.preview_pair(&kb.scroll_preview_left, &kb.scroll_preview_right),
+            "A / B"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fix horizontal preview scroll shortcuts in the help overlay showing as `Shift+H` / `Shift+L`.

The overlay now shows `H` / `L`, matching other uppercase character bindings. Preview shortcuts use the shared key-pair formatter, with regression coverage for default and custom bindings.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo check --target i686-unknown-linux-gnu`
- [x] `cargo check`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [ ] Added a `CHANGELOG.md` entry for user-visible changes
- [x] Docs and changelog are not needed
