### PR TITLE
fix(preview): show license icons in archive previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a configurable `toggle_preview` (`V`) shortcut to show or hide the preview pane. ([#251])
 - Added a configurable `fullscreen_preview` (`P`) shortcut to temporarily expand the preview pane.
 
+### Fixed
+
+- Fixed license icons in archive previews.
+
 ## [1.11.2] - 2026-07-22
 
 ### Fixed

--- a/src/file_info/license.rs
+++ b/src/file_info/license.rs
@@ -86,7 +86,7 @@ pub(super) fn sniff_license_file_type(
     ext: &str,
     base_facts: FileFacts,
 ) -> Option<FileFacts> {
-    let canonical_candidate = is_canonical_license_candidate_name(name);
+    let canonical_candidate = is_canonical_license_candidate_key(name);
     let can_sniff_content = can_sniff_license_content(base_facts);
     let can_sniff_markers = can_sniff_license_markers(ext, base_facts);
 
@@ -118,7 +118,7 @@ pub(super) fn sniff_browser_license_file_type(
     ext: &str,
     base_facts: FileFacts,
 ) -> Option<FileFacts> {
-    let canonical_candidate = is_canonical_license_candidate_name(name);
+    let canonical_candidate = is_canonical_license_candidate_key(name);
     let can_sniff_content = can_sniff_license_content(base_facts);
     let can_sniff_markers = can_sniff_license_markers(ext, base_facts);
 
@@ -159,7 +159,12 @@ fn can_sniff_license_content(base_facts: FileFacts) -> bool {
     )
 }
 
-fn is_canonical_license_candidate_name(name: &str) -> bool {
+pub(crate) fn is_canonical_license_file_name(name: &str) -> bool {
+    let name = name.trim().to_ascii_lowercase();
+    is_canonical_license_candidate_key(&name)
+}
+
+fn is_canonical_license_candidate_key(name: &str) -> bool {
     const EXACT_CANDIDATES: &[&str] = &["license", "licence", "copying", "copyright", "unlicense"];
     const PREFIX_CANDIDATES: &[&str] = &["license", "licence", "copying", "copyright", "unlicense"];
 

--- a/src/file_info/mod.rs
+++ b/src/file_info/mod.rs
@@ -12,6 +12,7 @@ pub(crate) use self::archives::inspect_compound_archive_name;
 pub(crate) use self::classify::{
     inspect_entry_cached, inspect_entry_fast, inspect_path, inspect_path_cached,
 };
+pub(crate) use self::license::is_canonical_license_file_name;
 pub(crate) use self::types::{
     CodeBackend, CompoundArchiveKind, CompressionKind, CustomCodeKind, DiskImageKind,
     DocumentFormat, FileFacts, PreviewKind, PreviewSpec, StructuredFormat,

--- a/src/preview/appearance.rs
+++ b/src/preview/appearance.rs
@@ -1,4 +1,4 @@
-use crate::core::{Entry, EntryKind};
+use crate::core::{Entry, EntryKind, FileClass};
 use ratatui::style::Color;
 use std::path::Path;
 
@@ -128,6 +128,18 @@ pub(crate) fn code_preview_palette() -> CodePreviewPalette {
 
 pub(crate) fn resolve_path(path: &Path, kind: EntryKind) -> PathAppearance<'static> {
     let appearance = crate::ui::theme::resolve_path(path, kind);
+    PathAppearance {
+        icon: appearance.icon,
+        color: appearance.color,
+    }
+}
+
+pub(crate) fn resolve_path_with_class(
+    path: &Path,
+    kind: EntryKind,
+    class: FileClass,
+) -> PathAppearance<'static> {
+    let appearance = crate::ui::theme::resolve_path_with_class(path, kind, class);
     PathAppearance {
         icon: appearance.icon,
         color: appearance.color,

--- a/src/preview/container/mod.rs
+++ b/src/preview/container/mod.rs
@@ -3,7 +3,10 @@ mod iso;
 mod torrent;
 
 use super::{appearance as theme, *};
-use crate::core::EntryKind;
+use crate::{
+    core::{EntryKind, FileClass},
+    file_info,
+};
 use ratatui::{
     style::Style,
     text::{Line, Span},
@@ -192,14 +195,22 @@ fn render_archive_tree_line(
     palette: theme::Palette,
 ) -> Line<'static> {
     let connector = if is_last { "└── " } else { "├── " };
-    let appearance = theme::resolve_path(
-        Path::new(&node.path),
-        if node.is_dir {
-            EntryKind::Directory
-        } else {
-            EntryKind::File
-        },
-    );
+    let path = Path::new(&node.path);
+    let kind = if node.is_dir {
+        EntryKind::Directory
+    } else {
+        EntryKind::File
+    };
+    let license_entry = !node.is_dir
+        && path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(file_info::is_canonical_license_file_name);
+    let appearance = if license_entry {
+        theme::resolve_path_with_class(path, kind, FileClass::License)
+    } else {
+        theme::resolve_path(path, kind)
+    };
     let mut display_name = name.to_string();
     if node.is_dir {
         display_name.push('/');

--- a/src/preview/tests/archives.rs
+++ b/src/preview/tests/archives.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::core::{EntryKind, FileClass};
+use std::path::Path;
 
 #[test]
 fn torrent_preview_shows_single_file_metadata_and_trackers() {
@@ -361,6 +363,47 @@ fn zip_preview_renders_archive_details_and_tree() {
     assert!(line_texts.iter().any(|text| text.contains("src/")));
     assert!(line_texts.iter().any(|text| text.contains("readme.txt")));
     assert!(line_texts.iter().any(|text| text.contains("main.rs")));
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn zip_preview_uses_license_icon_for_canonical_license_entries() {
+    let root = temp_path("zip-license-icons");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("licenses.zip");
+    write_zip_entries(
+        &path,
+        &[
+            ("LICENSE", "MIT License\n"),
+            ("LICENSE-MIT", "MIT License\n"),
+            ("COPYING.LESSER", "GNU Lesser General Public License\n"),
+            ("UNLICENSE", "The Unlicense\n"),
+            ("license/readme.txt", "not a license directory\n"),
+        ],
+    );
+
+    let preview = build_preview(&file_entry(path));
+    let license_icon =
+        theme::resolve_path_with_class(Path::new("LICENSE"), EntryKind::File, FileClass::License)
+            .icon;
+    let directory_icon = theme::resolve_path(Path::new("license"), EntryKind::Directory).icon;
+
+    for name in ["LICENSE", "LICENSE-MIT", "COPYING.LESSER", "UNLICENSE"] {
+        let line = preview
+            .lines
+            .iter()
+            .find(|line| line_text(line).contains(name))
+            .unwrap_or_else(|| panic!("archive preview should show {name}"));
+        assert_eq!(line.spans[1].content.trim(), license_icon);
+    }
+
+    let directory_line = preview
+        .lines
+        .iter()
+        .find(|line| line_text(line).contains("license/"))
+        .expect("archive preview should show the license directory");
+    assert_eq!(directory_line.spans[1].content.trim(), directory_icon);
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }


### PR DESCRIPTION
## Summary

Fix archive preview content trees so canonical license files use the license icon instead of the generic file icon.

The fix is scoped to synthetic archive/container entries, so normal filesystem entries still rely on content sniffing to avoid filename-only false positives.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed