### PR TITLE
fix(ui): mask archive creation popups over previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed license icons in archive previews.
+- Fixed image previews bleeding through archive creation popups in transparent themes.
 
 ## [1.11.2] - 2026-07-22
 

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -629,6 +629,9 @@ impl App {
         if let Some(r) = self.input.frame_state.archive_password_panel {
             rects.push(r);
         }
+        if let Some(r) = self.input.frame_state.archive_create_panel {
+            rects.push(r);
+        }
         if let Some(r) = self.input.frame_state.create_panel {
             rects.push(r);
         }
@@ -657,6 +660,7 @@ impl App {
         self.overlays.trash.is_some()
             || self.overlays.restore.is_some()
             || self.overlays.archive_password.is_some()
+            || self.overlays.archive_create.is_some()
             || self.overlays.create.is_some()
             || self.overlays.rename.is_some()
             || self.overlays.bulk_rename.is_some()

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1033,6 +1033,10 @@ fn archive_create_overlay_adapts_contents_to_short_terminals() {
             shows_contents,
             "contents visibility should track whether a complete row fits at height {height}"
         );
+        assert!(
+            app.collect_popup_rects().contains(&panel),
+            "archive creation popup should mask terminal image previews"
+        );
         if !shows_contents {
             assert_eq!(panel.height, 6, "compact popup should not leave dead rows");
         }


### PR DESCRIPTION
## Summary

Fix archive creation popups so image previews no longer bleed through them in transparent themes.

The popup now participates in the same modal image masking path as rename and create overlays.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed