### PR TITLE
fix(preview): redraw image overlays after terminal tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed license icons in archive previews.
 - Fixed image previews bleeding through archive creation popups in transparent themes.
+- Fixed image previews disappearing after returning from actions that suspend and restore the TUI.
 
 ## [1.11.2] - 2026-07-22
 

--- a/src/app/overlays/inline_image/mod.rs
+++ b/src/app/overlays/inline_image/mod.rs
@@ -258,6 +258,23 @@ impl App {
         }
     }
 
+    pub(crate) fn invalidate_terminal_image_overlay_after_terminal_task(&mut self) {
+        if self.preview.terminal_images.protocol == ImageProtocol::None
+            || (!self.static_image_overlay_displayed() && !self.pdf_overlay_displayed())
+        {
+            return;
+        }
+
+        // zoxide, Shell Here, Open With, and editor-based actions temporarily
+        // hand the real terminal to another program. That program may leave the
+        // alternate screen, clear it, or simply overpaint the image cells. The
+        // terminal-side image is no longer trustworthy even though elio's active
+        // preview request still matches the last displayed overlay, so force the
+        // next frame through the same full-repaint path used after image geometry
+        // changes and let normal presentation re-place the image.
+        self.preview.terminal_images.pending_resize_clear = true;
+    }
+
     pub(crate) fn take_pending_resize_clear(&mut self) -> bool {
         if !self.preview.terminal_images.pending_resize_clear {
             return false;

--- a/src/app/overlays/preview_visual/tests/document.rs
+++ b/src/app/overlays/preview_visual/tests/document.rs
@@ -734,6 +734,40 @@ fn leaving_fullscreen_preview_queues_image_geometry_clear() {
 }
 
 #[test]
+fn returning_from_terminal_task_replaces_logically_displayed_image() {
+    let (mut app, root) = build_displayed_iterm_inline_image_app("terminal-task-image-restore");
+    assert!(app.static_image_overlay_displayed());
+    assert!(app.displayed_static_image_matches_active());
+    assert!(
+        app.present_preview_overlay()
+            .expect("steady-state image presentation should not fail")
+            .is_empty(),
+        "a matching logical image would otherwise skip re-placement"
+    );
+
+    app.invalidate_terminal_image_overlay_after_terminal_task();
+    assert!(
+        app.take_pending_resize_clear(),
+        "returning from a terminal task should force a full image repaint"
+    );
+    assert!(
+        !app.static_image_overlay_displayed(),
+        "terminal-task invalidation should drop stale logical image state"
+    );
+
+    let restored = String::from_utf8(
+        app.present_preview_overlay()
+            .expect("re-presenting after terminal task should not fail"),
+    )
+    .expect("restored iTerm image output should be valid utf8");
+    assert!(restored.contains("\x1b]1337;File=inline=1;"));
+    assert!(app.static_image_overlay_displayed());
+    assert!(app.displayed_static_image_matches_active());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn resize_settle_holds_image_placement_until_window_expires() {
     let (mut app, root) = build_displayed_iterm_inline_image_app("resize-settle-hold");
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -446,6 +446,7 @@ fn run_app(
                         suspend_terminal(terminal, drainer, true, kitty_dnd)?;
                         run_blocking_in_terminal(&program, &args);
                         resume_terminal(terminal, drainer, kitty_dnd)?;
+                        app.invalidate_terminal_image_overlay_after_terminal_task();
                         pause_runtime_input(&input_reader, false);
                         None
                     }
@@ -456,6 +457,7 @@ fn run_app(
                             run_blocking_in_terminal(&program, &args);
                         }
                         resume_terminal(terminal, drainer, kitty_dnd)?;
+                        app.invalidate_terminal_image_overlay_after_terminal_task();
                         pause_runtime_input(&input_reader, false);
                         None
                     }
@@ -469,6 +471,7 @@ fn run_app(
                         suspend_terminal(terminal, drainer, true, kitty_dnd)?;
                         let result = run_blocking_in_terminal_result(&program, &args);
                         resume_terminal(terminal, drainer, kitty_dnd)?;
+                        app.invalidate_terminal_image_overlay_after_terminal_task();
                         pause_runtime_input(&input_reader, false);
                         if let Err(error) = app.finish_editor_bulk_rename(session, result) {
                             app.report_runtime_error("Editor rename failed", &error);
@@ -480,6 +483,7 @@ fn run_app(
                         suspend_terminal(terminal, drainer, true, kitty_dnd)?;
                         let shell_result = shell::run_in_current_terminal(&cwd);
                         resume_terminal(terminal, drainer, kitty_dnd)?;
+                        app.invalidate_terminal_image_overlay_after_terminal_task();
                         pause_runtime_input(&input_reader, false);
                         match shell_result {
                             Ok(()) => refresh_after_shell(&mut app, &cwd),
@@ -496,6 +500,7 @@ fn run_app(
                             suspend_terminal(terminal, drainer, false, kitty_dnd)?;
                             let result = zoxide::run_query_in_terminal(&cwd);
                             resume_terminal(terminal, drainer, kitty_dnd)?;
+                            app.invalidate_terminal_image_overlay_after_terminal_task();
                             pause_runtime_input(&input_reader, false);
                             Some(result)
                         }


### PR DESCRIPTION
## Summary

Fix image previews disappearing after returning from actions that temporarily suspend and restore the TUI.

Terminal-side image state is now invalidated after terminal handoffs, so previews are redrawn instead of being skipped as already displayed.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed