### PR TITLE
fix(input): handle pasted text as paste input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed license icons in archive previews.
 - Fixed image previews bleeding through archive creation popups in transparent themes.
 - Fixed image previews disappearing after returning from actions that suspend and restore the TUI.
+- Fixed pasted text being handled as normal keystrokes.
 
 ## [1.11.2] - 2026-07-22
 

--- a/src/runtime/terminal.rs
+++ b/src/runtime/terminal.rs
@@ -6,8 +6,8 @@ use anyhow::Result;
 use crossterm::{
     cursor::SetCursorStyle,
     event::{
-        self, DisableFocusChange, EnableFocusChange, KeyboardEnhancementFlags,
-        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+        self, DisableBracketedPaste, DisableFocusChange, EnableBracketedPaste, EnableFocusChange,
+        KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute,
     terminal::{
@@ -210,6 +210,7 @@ fn try_init_terminal() -> Result<(AppTerminal, Drainer, KittyDndRuntime)> {
         terminal_output,
         EnterAlternateScreen,
         event::EnableMouseCapture,
+        EnableBracketedPaste,
         EnableFocusChange
     )?;
 
@@ -297,6 +298,7 @@ pub(super) fn suspend_terminal(
     execute!(
         terminal.backend_mut(),
         event::DisableMouseCapture,
+        DisableBracketedPaste,
         DisableFocusChange,
         SetCursorStyle::DefaultUserShape
     )?;
@@ -332,6 +334,7 @@ pub(super) fn resume_terminal(
             backend,
             EnterAlternateScreen,
             event::EnableMouseCapture,
+            EnableBracketedPaste,
             EnableFocusChange,
         )?;
         write!(backend, "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h")?;
@@ -370,6 +373,7 @@ pub(super) fn restore_terminal(
     execute!(
         terminal.backend_mut(),
         event::DisableMouseCapture,
+        DisableBracketedPaste,
         DisableFocusChange,
         SetCursorStyle::DefaultUserShape,
         LeaveAlternateScreen
@@ -393,6 +397,7 @@ fn cleanup_terminal_state() -> io::Result<()> {
         let _ = execute!(
             terminal_output,
             event::DisableMouseCapture,
+            DisableBracketedPaste,
             DisableFocusChange,
             SetCursorStyle::DefaultUserShape,
             LeaveAlternateScreen,


### PR DESCRIPTION
## Summary

Fix pasted text being handled as normal keystrokes.

Bracketed paste is now enabled while elio owns the terminal and disabled again when the TUI is suspended, restored, or cleaned up.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed