### PR TITLE
fix(input): allow paste in text fields

### DIFF
--- a/src/app/create/editing.rs
+++ b/src/app/create/editing.rs
@@ -5,7 +5,7 @@ use super::super::text_edit::{
 };
 
 impl App {
-    pub(in crate::app::create) fn create_insert_newline(&mut self) {
+    pub(in crate::app) fn create_insert_newline(&mut self) {
         let Some(c) = &mut self.overlays.create else {
             return;
         };

--- a/src/app/input/keyboard.rs
+++ b/src/app/input/keyboard.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::app::text_edit::{
+    char_to_byte, insert_text_at_cursor, multiline_paste_text, single_line_paste_text,
+};
 
 const HELP_FALLBACK_SCROLL_MAX: usize = 64;
 const HELP_FALLBACK_PAGE_STEP: usize = 8;
@@ -8,13 +11,147 @@ impl App {
         let result = match event {
             Event::Key(key) => self.handle_key(key),
             Event::Mouse(mouse) => self.handle_mouse(mouse),
-            Event::Resize(_, _) | Event::FocusGained | Event::FocusLost | Event::Paste(_) => Ok(()),
+            Event::Paste(text) => self.handle_paste(&text),
+            Event::Resize(_, _) | Event::FocusGained | Event::FocusLost => Ok(()),
         };
 
         if let Err(error) = result {
             self.report_runtime_error("Action failed", &error);
         }
 
+        Ok(())
+    }
+
+    fn handle_paste(&mut self, text: &str) -> Result<()> {
+        if self.overlays.trash.is_some() || self.overlays.restore.is_some() {
+            return Ok(());
+        }
+
+        if self.overlays.archive_password.is_some() {
+            return self.paste_into_archive_password(text);
+        }
+
+        if self.overlays.archive_create.is_some() {
+            return self.paste_into_archive_create(text);
+        }
+
+        if self.overlays.create.is_some() {
+            return self.paste_into_create(text);
+        }
+
+        if self.overlays.rename.is_some() {
+            return self.paste_into_rename(text);
+        }
+
+        if self.overlays.bulk_rename.is_some() {
+            return self.paste_into_bulk_rename(text);
+        }
+
+        if self.overlays.editor_rename_confirm.is_some()
+            || self.overlays.goto.is_some()
+            || self.overlays.copy.is_some()
+            || self.overlays.open_with.is_some()
+        {
+            return Ok(());
+        }
+
+        if self.overlays.search.is_some() {
+            return self.paste_into_search(text);
+        }
+
+        if self.local_filter_is_editing() {
+            return self.paste_into_local_filter(text);
+        }
+
+        Ok(())
+    }
+
+    fn paste_into_archive_password(&mut self, text: &str) -> Result<()> {
+        let text = single_line_paste_text(text);
+        if let Some(overlay) = &mut self.overlays.archive_password {
+            insert_text_at_cursor(&mut overlay.input, &mut overlay.cursor_col, &text);
+            overlay.error = None;
+        }
+        Ok(())
+    }
+
+    fn paste_into_archive_create(&mut self, text: &str) -> Result<()> {
+        let text = single_line_paste_text(text);
+        if let Some(overlay) = &mut self.overlays.archive_create {
+            insert_text_at_cursor(&mut overlay.input, &mut overlay.cursor_col, &text);
+            overlay.error = None;
+        }
+        Ok(())
+    }
+
+    fn paste_into_create(&mut self, text: &str) -> Result<()> {
+        let text = multiline_paste_text(text);
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        for ch in text.chars() {
+            if ch == '\n' {
+                self.create_insert_newline();
+                continue;
+            }
+            if let Some(overlay) = &mut self.overlays.create {
+                let byte = char_to_byte(&overlay.lines[overlay.cursor_line], overlay.cursor_col);
+                overlay.lines[overlay.cursor_line].insert(byte, ch);
+                overlay.cursor_col += 1;
+                overlay.preferred_col = overlay.cursor_col;
+                overlay.line_errors[overlay.cursor_line] = None;
+            }
+        }
+        Ok(())
+    }
+
+    fn paste_into_rename(&mut self, text: &str) -> Result<()> {
+        let text = single_line_paste_text(text);
+        if let Some(overlay) = &mut self.overlays.rename {
+            insert_text_at_cursor(&mut overlay.input, &mut overlay.cursor_col, &text);
+            overlay.error = None;
+        }
+        Ok(())
+    }
+
+    fn paste_into_bulk_rename(&mut self, text: &str) -> Result<()> {
+        let text = single_line_paste_text(text);
+        if let Some(overlay) = &mut self.overlays.bulk_rename {
+            insert_text_at_cursor(
+                &mut overlay.new_names[overlay.cursor_line],
+                &mut overlay.cursor_col,
+                &text,
+            );
+            overlay.preferred_col = overlay.cursor_col;
+            overlay.line_errors[overlay.cursor_line] = None;
+        }
+        Ok(())
+    }
+
+    fn paste_into_search(&mut self, text: &str) -> Result<()> {
+        let text = single_line_paste_text(text);
+        let previous_query = self
+            .overlays
+            .search
+            .as_ref()
+            .map(|search| search.query.clone())
+            .unwrap_or_default();
+        if let Some(search) = &mut self.overlays.search {
+            insert_text_at_cursor(&mut search.query, &mut search.query_cursor, &text);
+        }
+        self.refresh_search_matches(&previous_query);
+        Ok(())
+    }
+
+    fn paste_into_local_filter(&mut self, text: &str) -> Result<()> {
+        let text = single_line_paste_text(text);
+        insert_text_at_cursor(
+            &mut self.navigation.local_filter.query,
+            &mut self.navigation.local_filter.cursor,
+            &text,
+        );
+        self.apply_local_filter_preserving_selection();
         Ok(())
     }
 

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -84,6 +84,176 @@ fn fake_default_open_with_app(
     }
 }
 
+#[test]
+fn pasted_text_is_ignored_in_browser_mode() {
+    let root = temp_path("paste-browser-ignored");
+    fs::write(root.join("alpha.txt"), "").expect("failed to write alpha");
+    fs::write(root.join("beta.txt"), "").expect("failed to write beta");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    let selected_before = app.selected_entry().map(|entry| entry.path.clone());
+
+    app.handle_event(Event::Paste("jjjj".to_string()))
+        .expect("paste event should be accepted");
+
+    assert_eq!(
+        app.selected_entry().map(|entry| entry.path.clone()),
+        selected_before
+    );
+
+    cleanup_app_temp_root(app, root);
+}
+
+#[test]
+fn pasted_text_updates_fuzzy_search_query() {
+    let root = temp_path("paste-search");
+    fs::write(root.join("alpha.txt"), "").expect("failed to write alpha");
+    fs::write(root.join("beta.txt"), "").expect("failed to write beta");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.open_fuzzy_finder(SearchScope::Files)
+        .expect("failed to open fuzzy finder");
+
+    app.handle_event(Event::Paste("beta".to_string()))
+        .expect("paste event should update search");
+
+    assert_eq!(app.search_query(), "beta");
+    assert_eq!(app.search_query_cursor(), 4);
+
+    cleanup_app_temp_root(app, root);
+}
+
+#[test]
+fn pasted_text_updates_local_filter() {
+    let root = temp_path("paste-local-filter");
+    fs::write(root.join("alpha.txt"), "").expect("failed to write alpha");
+    fs::write(root.join("beta.txt"), "").expect("failed to write beta");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.open_local_filter();
+
+    app.handle_event(Event::Paste("beta".to_string()))
+        .expect("paste event should update filter");
+
+    assert_eq!(app.local_filter_query(), "beta");
+    assert_eq!(
+        app.selected_entry().map(|entry| entry.name.as_str()),
+        Some("beta.txt")
+    );
+
+    cleanup_app_temp_root(app, root);
+}
+
+#[test]
+fn pasted_text_does_not_reach_local_filter_under_non_text_overlay() {
+    let root = temp_path("paste-local-filter-shadowed");
+    fs::write(root.join("alpha.txt"), "").expect("failed to write alpha");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.open_local_filter();
+    app.open_copy_overlay();
+
+    app.handle_event(Event::Paste("hidden".to_string()))
+        .expect("paste event should be ignored by non-text overlay");
+
+    assert!(app.copy_is_open());
+    assert_eq!(app.local_filter_query(), "");
+
+    cleanup_app_temp_root(app, root);
+}
+
+#[test]
+fn pasted_text_updates_create_prompt_without_submitting() {
+    let root = temp_path("paste-create");
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.open_create_prompt();
+
+    app.handle_event(Event::Paste("one.txt\ntwo.txt".to_string()))
+        .expect("paste event should update create prompt");
+
+    assert!(app.create_is_open());
+    assert_eq!(app.create_line_count(), 2);
+    assert_eq!(app.create_line(0), "one.txt");
+    assert_eq!(app.create_line(1), "two.txt");
+    assert_eq!(app.create_cursor_line(), 1);
+    assert_eq!(app.create_cursor_col(), 7);
+
+    cleanup_app_temp_root(app, root);
+}
+
+#[test]
+fn pasted_text_updates_rename_prompt_at_cursor() {
+    let root = temp_path("paste-rename");
+    fs::write(root.join("report.txt"), "draft").expect("failed to write report");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.open_rename_prompt();
+
+    app.handle_event(Event::Paste("-final".to_string()))
+        .expect("paste event should update rename prompt");
+
+    assert_eq!(app.rename_input(), "report-final.txt");
+    assert_eq!(app.rename_cursor_col(), "report-final".chars().count());
+
+    cleanup_app_temp_root(app, root);
+}
+
+#[test]
+fn pasted_text_updates_bulk_rename_prompt_at_active_row() {
+    let root = temp_path("paste-bulk-rename");
+    fs::write(root.join("alpha.txt"), "alpha").expect("failed to write alpha");
+    fs::write(root.join("beta.txt"), "beta").expect("failed to write beta");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.navigation.selected_paths.insert(root.join("alpha.txt"));
+    app.navigation.selected_paths.insert(root.join("beta.txt"));
+    app.open_bulk_rename_prompt();
+
+    app.handle_event(Event::Paste("renamed-".to_string()))
+        .expect("paste event should update bulk rename prompt");
+
+    assert_eq!(app.bulk_rename_new_name(0), "renamed-alpha.txt");
+    assert_eq!(app.bulk_rename_new_name(1), "beta.txt");
+    assert_eq!(app.bulk_rename_cursor_col(), "renamed-".chars().count());
+
+    cleanup_app_temp_root(app, root);
+}
+
+#[test]
+fn pasted_text_updates_archive_create_name_at_cursor() {
+    let root = temp_path("paste-archive-create");
+    fs::write(root.join("alpha.txt"), "alpha").expect("failed to write alpha");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.open_archive_create_prompt();
+
+    app.handle_event(Event::Paste("-backup".to_string()))
+        .expect("paste event should update archive create prompt");
+
+    assert_eq!(app.archive_create_input(), "alpha.txt-backup.zip");
+    assert_eq!(
+        app.archive_create_cursor_col(),
+        "alpha.txt-backup".chars().count()
+    );
+
+    cleanup_app_temp_root(app, root);
+}
+
+#[test]
+fn pasted_text_updates_archive_password_and_flattens_newlines() {
+    let root = temp_path("paste-archive-password");
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    app.open_archive_password_prompt(root.join("archive.zip"), None);
+
+    app.handle_event(Event::Paste("pa\nss".to_string()))
+        .expect("paste event should update archive password prompt");
+
+    assert_eq!(app.archive_password_input(), "pa ss");
+    assert_eq!(app.archive_password_cursor_col(), "pa ss".chars().count());
+
+    cleanup_app_temp_root(app, root);
+}
+
 fn app_with_offscreen_selected_dir(label: &str) -> (PathBuf, PathBuf, App) {
     let root = temp_path(label);
     let offscreen = root.join("offscreen");

--- a/src/app/text_edit.rs
+++ b/src/app/text_edit.rs
@@ -10,6 +10,34 @@ pub(super) fn char_to_byte(s: &str, char_idx: usize) -> usize {
         .unwrap_or(s.len())
 }
 
+pub(super) fn insert_text_at_cursor(text: &mut String, cursor: &mut usize, inserted: &str) {
+    let byte = char_to_byte(text, *cursor);
+    text.insert_str(byte, inserted);
+    *cursor += inserted.chars().count();
+}
+
+pub(super) fn single_line_paste_text(text: &str) -> String {
+    normalize_paste_newlines(text)
+        .chars()
+        .filter_map(|ch| match ch {
+            '\n' => Some(' '),
+            ch if ch.is_control() && ch != '\t' => None,
+            ch => Some(ch),
+        })
+        .collect()
+}
+
+pub(super) fn multiline_paste_text(text: &str) -> String {
+    normalize_paste_newlines(text)
+        .chars()
+        .filter(|ch| *ch == '\n' || !ch.is_control() || *ch == '\t')
+        .collect()
+}
+
+fn normalize_paste_newlines(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
 /// Move cursor left to the start of the previous word (shell-style).
 pub(super) fn previous_word_start(text: &str, cursor: usize) -> usize {
     let chars: Vec<char> = text.chars().collect();


### PR DESCRIPTION
## Summary

Fix paste handling from #257 so bracketed paste is still ignored in browser mode, but works in active text fields.

Paste is now routed to search, filter, create, rename, archive creation, and archive password prompts.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [ ] Added a `CHANGELOG.md` entry for user-visible changes
- [x] Docs and changelog are not needed