### PR TITLE
feat: add bulk archive extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a configurable `toggle_preview` (`V`) shortcut to show or hide the preview pane. ([#251])
 - Added a configurable `fullscreen_preview` (`P`) shortcut to temporarily expand the preview pane.
+- Added bulk archive extraction for selected archives. ([#241])
 
 ### Changed
 
@@ -325,6 +326,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.1]: https://github.com/elio-fm/elio/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/elio-fm/elio/releases/tag/v1.0.0
 [#251]: https://github.com/elio-fm/elio/issues/251
+[#241]: https://github.com/elio-fm/elio/issues/241
 [#240]: https://github.com/elio-fm/elio/issues/240
 [#235]: https://github.com/elio-fm/elio/issues/235
 [#232]: https://github.com/elio-fm/elio/issues/232

--- a/src/app/actions/archive.rs
+++ b/src/app/actions/archive.rs
@@ -5,7 +5,6 @@ use crate::app::text_edit::{
 };
 use crate::archive::{ArchiveEncryption, ArchivePassword};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-use std::path::PathBuf;
 
 impl App {
     pub fn archive_extract_progress(&self) -> Option<(usize, Option<usize>)> {
@@ -21,6 +20,10 @@ impl App {
             return Ok(());
         }
 
+        if self.selection_count() > 0 {
+            return self.extract_selected_archives();
+        }
+
         let Some(entry) = self.selected_entry() else {
             self.status = "Select an archive to extract".to_string();
             return Ok(());
@@ -31,7 +34,46 @@ impl App {
         }
 
         let archive_path = entry.path.clone();
-        let _ = self.start_archive_extract(archive_path, None)?;
+        let request = ArchiveExtractRequest {
+            token: 0,
+            archives: vec![archive_path.clone()],
+            password: None,
+            batch: ArchiveExtractBatchState::new(1, 0),
+        };
+        if let Err(error) = crate::archive::plan_extract(&archive_path) {
+            self.status = error.to_string();
+            return Ok(());
+        }
+        let _ = self.start_archive_extract(request)?;
+        Ok(())
+    }
+
+    fn extract_selected_archives(&mut self) -> Result<()> {
+        let selected = self.selected_paths_sorted();
+        let mut archives = Vec::new();
+        let mut skipped_non_archives = 0usize;
+        for path in selected {
+            if path.is_file() && crate::archive::plan_extract(&path).is_ok() {
+                archives.push(path);
+            } else {
+                skipped_non_archives += 1;
+            }
+        }
+
+        if archives.is_empty() {
+            self.status = "No archives selected".to_string();
+            return Ok(());
+        }
+
+        let request = ArchiveExtractRequest {
+            token: 0,
+            batch: ArchiveExtractBatchState::new(archives.len(), skipped_non_archives),
+            archives,
+            password: None,
+        };
+        if self.start_archive_extract(request)? {
+            self.navigation.selected_paths.clear();
+        }
         Ok(())
     }
 
@@ -44,8 +86,10 @@ impl App {
             return "archive".to_string();
         };
         match &overlay.purpose {
-            ArchivePasswordPurpose::Extract { archive_path } => archive_path
-                .file_name()
+            ArchivePasswordPurpose::Extract { request } => request
+                .archives
+                .first()
+                .and_then(|path| path.file_name())
                 .and_then(|name| name.to_str())
                 .unwrap_or("archive")
                 .to_string(),
@@ -105,7 +149,7 @@ impl App {
 
     pub(in crate::app) fn open_archive_password_prompt(
         &mut self,
-        archive_path: PathBuf,
+        request: ArchiveExtractRequest,
         error: Option<String>,
     ) {
         self.overlays.help = false;
@@ -119,7 +163,7 @@ impl App {
         self.overlays.open_with = None;
         self.overlays.search = None;
         self.overlays.archive_password = Some(ArchivePasswordOverlay {
-            purpose: ArchivePasswordPurpose::Extract { archive_path },
+            purpose: ArchivePasswordPurpose::Extract { request },
             input: String::new(),
             cursor_col: 0,
             visible: false,
@@ -143,7 +187,7 @@ impl App {
 
     pub(in crate::app) fn handle_archive_password_key(&mut self, key: KeyEvent) -> Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
-            self.overlays.archive_password = None;
+            self.cancel_archive_password_prompt()?;
             return Ok(());
         }
 
@@ -154,7 +198,7 @@ impl App {
 
         match key.code {
             KeyCode::Esc => {
-                self.overlays.archive_password = None;
+                self.cancel_archive_password_prompt()?;
             }
             KeyCode::Enter if key.modifiers == KeyModifiers::NONE => {
                 self.confirm_archive_password()?;
@@ -304,7 +348,7 @@ impl App {
                 .archive_password_panel
                 .is_some_and(|panel| rect_contains(panel, mouse.column, mouse.row));
             if !inside {
-                self.overlays.archive_password = None;
+                self.cancel_archive_password_prompt()?;
             }
         }
         Ok(())
@@ -323,9 +367,10 @@ impl App {
         }
 
         match &overlay.purpose {
-            ArchivePasswordPurpose::Extract { archive_path } => {
-                let archive_path = archive_path.clone();
-                if self.start_archive_extract(archive_path, Some(ArchivePassword::new(password)))? {
+            ArchivePasswordPurpose::Extract { request } => {
+                let mut request = request.clone();
+                request.password = Some(ArchivePassword::new(password));
+                if self.start_archive_extract(request)? {
                     self.overlays.archive_password = None;
                 }
             }
@@ -342,43 +387,87 @@ impl App {
         Ok(())
     }
 
-    fn start_archive_extract(
-        &mut self,
-        archive_path: PathBuf,
-        password: Option<ArchivePassword>,
-    ) -> Result<bool> {
+    fn cancel_archive_password_prompt(&mut self) -> Result<()> {
+        let Some(overlay) = self.overlays.archive_password.take() else {
+            return Ok(());
+        };
+        if let ArchivePasswordPurpose::Extract { request } = overlay.purpose {
+            self.skip_password_archive(request)?;
+        }
+        Ok(())
+    }
+
+    fn skip_password_archive(&mut self, mut request: ArchiveExtractRequest) -> Result<()> {
+        if !request.archives.is_empty() {
+            request.archives.remove(0);
+            request.batch.skipped_archives += 1;
+        }
+        request.password = None;
+        if request.archives.is_empty() {
+            self.finish_archive_extract_batch(request.batch);
+            return Ok(());
+        }
+        let _ = self.start_archive_extract(request)?;
+        Ok(())
+    }
+
+    pub(in crate::app) fn finish_archive_extract_batch(&mut self, batch: ArchiveExtractBatchState) {
+        let status = batch.status();
+        let dest_dir = batch.reselect_path();
+        let source_cwd = self
+            .jobs
+            .archive_extract_source_cwd
+            .take()
+            .unwrap_or_else(|| self.navigation.cwd.clone());
+        self.jobs.archive_extract_request = None;
+        let nav_target = self
+            .navigation
+            .directory_runtime
+            .pending_load
+            .as_ref()
+            .map(|l| l.target_cwd.as_path());
+        let nav_to_source = nav_target == Some(source_cwd.as_path());
+        if nav_to_source || (source_cwd == self.navigation.cwd && nav_target.is_none()) {
+            let _ = self.queue_directory_load(PendingDirectoryLoad {
+                token: 0,
+                target_cwd: source_cwd,
+                previous_cwd: self.navigation.cwd.clone(),
+                previous_selected_path: None,
+                previous_selection_name: None,
+                reselect_path: dest_dir,
+                history_mode: DirectoryHistoryMode::None,
+                refresh_search: false,
+                completion: DirectoryLoadCompletion::Status(status),
+            });
+        } else {
+            self.status = status;
+        }
+    }
+
+    fn start_archive_extract(&mut self, mut request: ArchiveExtractRequest) -> Result<bool> {
         if self.jobs.archive_extract_progress.is_some() {
             self.status = "Extraction already in progress".to_string();
             return Ok(false);
         }
 
-        if let Err(error) = crate::archive::plan_extract(&archive_path) {
-            self.status = error.to_string();
-            return Ok(false);
-        }
-
         let token = self.jobs.archive_extract_token.wrapping_add(1);
         self.jobs.archive_extract_token = token;
+        request.token = token;
         self.jobs.archive_extract_progress = Some(ArchiveExtractProgress {
-            completed: 0,
-            total: None,
+            completed: request.batch.finished_archives(),
+            total: Some(request.batch.total_archives),
         });
-        self.jobs.archive_extract_source_cwd = Some(self.navigation.cwd.clone());
-        self.jobs.archive_extract_path = Some(archive_path.clone());
+        if self.jobs.archive_extract_source_cwd.is_none() {
+            self.jobs.archive_extract_source_cwd = Some(self.navigation.cwd.clone());
+        }
+        self.jobs.archive_extract_request = Some(request.clone());
         self.status.clear();
 
-        let submitted = self
-            .jobs
-            .scheduler
-            .submit_archive_extract(ArchiveExtractRequest {
-                token,
-                archive_path,
-                password,
-            });
+        let submitted = self.jobs.scheduler.submit_archive_extract(request);
         if !submitted {
             self.jobs.archive_extract_progress = None;
             self.jobs.archive_extract_source_cwd = None;
-            self.jobs.archive_extract_path = None;
+            self.jobs.archive_extract_request = None;
             self.status = "Extraction already in progress".to_string();
             return Ok(false);
         }

--- a/src/app/input/tests/archive.rs
+++ b/src/app/input/tests/archive.rs
@@ -39,6 +39,128 @@ fn e_extracts_focused_zip_archive() {
 }
 
 #[test]
+fn e_extracts_selected_archives_as_one_batch_and_skips_other_files() {
+    let root = temp_path("extract-selected-archives");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let alpha = root.join("alpha.zip");
+    let beta = root.join("beta.zip");
+    let notes = root.join("notes.pdf");
+    write_binary_zip_entries(&alpha, &[("file.txt", b"alpha")]);
+    write_binary_zip_entries(&beta, &[("file.txt", b"beta")]);
+    fs::write(&notes, b"not an archive").expect("failed to write non-archive");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(alpha.clone());
+    app.navigation.selected_paths.insert(beta.clone());
+    app.navigation.selected_paths.insert(notes);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('e'))))
+        .expect("e should start batch archive extraction");
+    assert!(
+        app.navigation.selected_paths.is_empty(),
+        "selected archives should be consumed once extraction starts"
+    );
+
+    let alpha_file = root.join("alpha/file.txt");
+    let beta_file = root.join("beta/file.txt");
+    for _ in 0..300 {
+        let _ = app.process_background_jobs();
+        if alpha_file.exists() && beta_file.exists() && app.jobs.archive_extract_progress.is_none()
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(fs::read_to_string(&alpha_file).unwrap(), "alpha");
+    assert_eq!(fs::read_to_string(&beta_file).unwrap(), "beta");
+    assert_eq!(
+        app.status_message(),
+        "Extracted 2 archives, skipped 1 non-archive"
+    );
+
+    cleanup_app_temp_root(app, root);
+}
+
+#[test]
+fn e_reports_no_archives_selected_for_non_archive_selection() {
+    let root = temp_path("extract-no-selected-archives");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let notes = root.join("notes.pdf");
+    fs::write(&notes, b"not an archive").expect("failed to write non-archive");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(notes);
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('e'))))
+        .expect("e should handle non-archive selection");
+
+    assert_eq!(app.status_message(), "No archives selected");
+    assert!(app.jobs.archive_extract_progress.is_none());
+    assert_eq!(
+        app.navigation.selected_paths.len(),
+        1,
+        "selection should stay when extraction does not start"
+    );
+
+    cleanup_app_temp_root(app, root);
+}
+
+#[test]
+fn e_skips_password_archive_on_cancel_and_continues_batch() {
+    let root = temp_path("extract-skip-password-archive");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let secret = root.join("secret.zip");
+    let alpha = root.join("alpha.zip");
+    let beta = root.join("beta.zip");
+    let password = archive_test_password(&root);
+    write_encrypted_zip_entries(&secret, &password, &[("file.txt", b"secret")]);
+    write_binary_zip_entries(&alpha, &[("file.txt", b"alpha")]);
+    write_binary_zip_entries(&beta, &[("file.txt", b"beta")]);
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(secret.clone());
+    app.navigation.selected_paths.insert(alpha.clone());
+    app.navigation.selected_paths.insert(beta.clone());
+
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Char('e'))))
+        .expect("e should start batch archive extraction");
+    assert!(
+        app.navigation.selected_paths.is_empty(),
+        "selected archives should be consumed before the password prompt"
+    );
+    wait_for_archive_password_prompt(&mut app);
+    app.handle_event(Event::Key(KeyEvent::from(KeyCode::Esc)))
+        .expect("esc should skip password archive");
+
+    let alpha_file = root.join("alpha/file.txt");
+    let beta_file = root.join("beta/file.txt");
+    for _ in 0..300 {
+        let _ = app.process_background_jobs();
+        if alpha_file.exists()
+            && beta_file.exists()
+            && app.jobs.archive_extract_progress.is_none()
+            && !app.archive_password_is_open()
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    wait_for_directory_load(&mut app);
+
+    assert!(!root.join("secret/file.txt").exists());
+    assert_eq!(fs::read_to_string(&alpha_file).unwrap(), "alpha");
+    assert_eq!(fs::read_to_string(&beta_file).unwrap(), "beta");
+    assert_eq!(app.status_message(), "Extracted 2 archives, 1 skipped");
+
+    cleanup_app_temp_root(app, root);
+}
+
+#[test]
 fn e_prompts_and_retries_encrypted_seven_zip_archive() {
     let root = temp_path("extract-encrypted-7z-key");
     fs::create_dir_all(&root).expect("failed to create temp root");

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -243,7 +243,15 @@ fn pasted_text_updates_archive_create_name_at_cursor() {
 fn pasted_text_updates_archive_password_and_flattens_newlines() {
     let root = temp_path("paste-archive-password");
     let mut app = App::new_at(root.clone()).expect("failed to create app");
-    app.open_archive_password_prompt(root.join("archive.zip"), None);
+    app.open_archive_password_prompt(
+        crate::app::jobs::ArchiveExtractRequest {
+            token: 0,
+            archives: vec![root.join("archive.zip")],
+            password: None,
+            batch: crate::app::jobs::ArchiveExtractBatchState::new(1, 0),
+        },
+        None,
+    );
 
     app.handle_event(Event::Paste("pa\nss".to_string()))
         .expect("paste event should update archive password prompt");

--- a/src/app/jobs/mod.rs
+++ b/src/app/jobs/mod.rs
@@ -12,14 +12,15 @@ pub(super) use self::metrics::SchedulerMetricsSnapshot;
 pub(super) use self::scheduler::JobScheduler;
 use self::sync::{lock_unpoison, wait_unpoison};
 pub(super) use self::types::{
-    ArchiveCreateBuild, ArchiveCreateRequest, ArchiveExtractBuild, ArchiveExtractRequest,
-    ArchivePasswordPrompt, DirectoryBuild, DirectoryFingerprintBuild, DirectoryFingerprintRequest,
-    DirectoryItemCountBuild, DirectoryItemCountRequest, DirectoryRequest, DirectoryStatsBuild,
-    DirectoryStatsRequest, GitStatusBuild, GitStatusRequest, ImageJobPriority, ImagePrepareBuild,
-    ImagePrepareRequest, JobResult, PasteBuild, PasteRequest, PdfJobPriority, PdfProbeBuild,
-    PdfProbeRequest, PdfRenderBuild, PdfRenderRequest, PreviewBuild, PreviewLineCountBuild,
-    PreviewLineCountRequest, PreviewPriority, PreviewRequest, RestoreBuild, RestoreRequest,
-    SearchBatchBuild, SearchBuild, SearchRequest, SixelPrepareConfig, TrashBuild, TrashRequest,
+    ArchiveCreateBuild, ArchiveCreateRequest, ArchiveExtractBatchState, ArchiveExtractBuild,
+    ArchiveExtractRequest, ArchivePasswordPrompt, DirectoryBuild, DirectoryFingerprintBuild,
+    DirectoryFingerprintRequest, DirectoryItemCountBuild, DirectoryItemCountRequest,
+    DirectoryRequest, DirectoryStatsBuild, DirectoryStatsRequest, GitStatusBuild, GitStatusRequest,
+    ImageJobPriority, ImagePrepareBuild, ImagePrepareRequest, JobResult, PasteBuild, PasteRequest,
+    PdfJobPriority, PdfProbeBuild, PdfProbeRequest, PdfRenderBuild, PdfRenderRequest, PreviewBuild,
+    PreviewLineCountBuild, PreviewLineCountRequest, PreviewPriority, PreviewRequest, RestoreBuild,
+    RestoreRequest, SearchBatchBuild, SearchBuild, SearchRequest, SixelPrepareConfig, TrashBuild,
+    TrashRequest,
 };
 use self::{config::SchedulerConfig, metrics::SchedulerMetrics};
 #[cfg(test)]

--- a/src/app/jobs/results/mod.rs
+++ b/src/app/jobs/results/mod.rs
@@ -288,23 +288,22 @@ impl App {
                     if build.done {
                         self.jobs.archive_extract_progress = None;
                         if let Some(prompt) = build.password_prompt {
-                            let archive_path = self.jobs.archive_extract_path.take();
-                            self.jobs.archive_extract_source_cwd = None;
-                            if let Some(archive_path) = archive_path {
+                            if let Some(request) = build.password_request {
                                 let error = match prompt {
                                     ArchivePasswordPrompt::Required => None,
                                     ArchivePasswordPrompt::BadPassword => {
                                         Some("Wrong password".to_string())
                                     }
                                 };
-                                self.open_archive_password_prompt(archive_path, error);
+                                self.jobs.archive_extract_request = Some(request.clone());
+                                self.open_archive_password_prompt(request, error);
                             } else {
                                 self.status = "Archive requires a password".to_string();
                             }
                             dirty = true;
                             continue;
                         }
-                        self.jobs.archive_extract_path = None;
+                        self.jobs.archive_extract_request = None;
                         let source_cwd = self
                             .jobs
                             .archive_extract_source_cwd

--- a/src/app/jobs/tasks/archive_extract.rs
+++ b/src/app/jobs/tasks/archive_extract.rs
@@ -116,112 +116,169 @@ impl ArchiveExtractShared {
 }
 
 fn run_extract(
-    request: ArchiveExtractRequest,
+    mut request: ArchiveExtractRequest,
     result_tx: &mpsc::Sender<JobResult>,
     cancelled: &AtomicBool,
     cancel_token: &AtomicU64,
 ) {
-    let mut completed = 0usize;
-    let mut total = None;
     let mut last_progress_at: Option<Instant> = None;
     let mut stopped_early = false;
+    let mut first_password = request.password.take();
+    let mut single_status = None;
+    let mut single_error_status = None;
 
-    let result = crate::archive::plan_extract(&request.archive_path)
-        .map_err(ExtractError::from)
-        .and_then(|plan| {
-            crate::archive::extract_archive_with_password(
-                &plan,
-                request.password.as_ref(),
-                |progress| {
-                    completed = progress.completed;
-                    total = progress.total;
-                    let _ = send_extract_progress(
-                        result_tx,
-                        request.token,
-                        completed,
-                        total,
-                        &mut last_progress_at,
-                    );
-                },
-                || {
-                    let stop = cancelled.load(Ordering::Relaxed)
-                        || cancel_token.load(Ordering::Relaxed) == request.token;
-                    if stop {
-                        stopped_early = true;
-                    }
-                    stop
-                },
-            )
-        });
+    while let Some(archive_path) = request.archives.first().cloned() {
+        if cancelled.load(Ordering::Relaxed)
+            || cancel_token.load(Ordering::Relaxed) == request.token
+        {
+            stopped_early = true;
+            break;
+        }
 
-    let mut password_prompt = None;
-    let (dest_dir, status) = match result {
-        Ok(summary) if stopped_early => {
-            let noun = if summary.completed == 1 {
-                "item"
+        let password = first_password.take();
+        let result = crate::archive::plan_extract(&archive_path)
+            .map_err(ExtractError::from)
+            .and_then(|plan| {
+                crate::archive::extract_archive_with_password(
+                    &plan,
+                    password.as_ref(),
+                    |_progress| {
+                        let _ = send_extract_progress(
+                            result_tx,
+                            request.token,
+                            request.batch.finished_archives(),
+                            Some(request.batch.total_archives),
+                            &mut last_progress_at,
+                        );
+                    },
+                    || {
+                        let stop = cancelled.load(Ordering::Relaxed)
+                            || cancel_token.load(Ordering::Relaxed) == request.token;
+                        if stop {
+                            stopped_early = true;
+                        }
+                        stop
+                    },
+                )
+            });
+
+        match result {
+            Ok(summary) if stopped_early => {
+                request.batch.dest_dirs.push(summary.dest_dir);
+                break;
+            }
+            Ok(summary) => {
+                if request.batch.is_single_archive() {
+                    let name = summary
+                        .dest_dir
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .unwrap_or("folder")
+                        .to_string();
+                    let noun = if summary.completed == 1 {
+                        "item"
+                    } else {
+                        "items"
+                    };
+                    let link_note = match summary.skipped_links {
+                        0 => String::new(),
+                        1 => " — skipped 1 unsafe link".to_string(),
+                        count => format!(" — skipped {count} unsafe links"),
+                    };
+                    single_status = Some(format!(
+                        "Extracted {} {noun} to \"{name}\"{link_note}",
+                        summary.completed
+                    ));
+                }
+                request.batch.completed_archives += 1;
+                request.batch.dest_dirs.push(summary.dest_dir);
+                request.archives.remove(0);
+            }
+            Err(ExtractError::PasswordRequired) => {
+                request.password = None;
+                send_extract_done(
+                    result_tx,
+                    ArchiveExtractBuild {
+                        token: request.token,
+                        completed: request.batch.finished_archives(),
+                        total: Some(request.batch.total_archives),
+                        done: true,
+                        dest_dir: None,
+                        status: None,
+                        password_prompt: Some(ArchivePasswordPrompt::Required),
+                        password_request: Some(request),
+                    },
+                );
+                return;
+            }
+            Err(ExtractError::BadPassword) => {
+                request.password = None;
+                send_extract_done(
+                    result_tx,
+                    ArchiveExtractBuild {
+                        token: request.token,
+                        completed: request.batch.finished_archives(),
+                        total: Some(request.batch.total_archives),
+                        done: true,
+                        dest_dir: None,
+                        status: None,
+                        password_prompt: Some(ArchivePasswordPrompt::BadPassword),
+                        password_request: Some(request),
+                    },
+                );
+                return;
+            }
+            Err(error) => {
+                if request.batch.is_single_archive() {
+                    let name = archive_path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .unwrap_or("archive");
+                    single_error_status = Some(format!("Cannot extract \"{name}\" — {error}"));
+                }
+                request.batch.failed_archives += 1;
+                request.archives.remove(0);
+            }
+        }
+
+        let _ = send_extract_progress(
+            result_tx,
+            request.token,
+            request.batch.finished_archives(),
+            Some(request.batch.total_archives),
+            &mut last_progress_at,
+        );
+    }
+
+    let status = if stopped_early {
+        Some(format!(
+            "Extraction cancelled — extracted {} {}",
+            request.batch.completed_archives,
+            if request.batch.completed_archives == 1 {
+                "archive"
             } else {
-                "items"
-            };
-            (
-                Some(summary.dest_dir),
-                format!(
-                    "Extraction cancelled — extracted {} {noun}",
-                    summary.completed
-                ),
-            )
-        }
-        Ok(summary) => {
-            let name = summary
-                .dest_dir
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or("folder")
-                .to_string();
-            let noun = if summary.completed == 1 {
-                "item"
-            } else {
-                "items"
-            };
-            let link_note = match summary.skipped_links {
-                0 => String::new(),
-                1 => " — skipped 1 unsafe link".to_string(),
-                count => format!(" — skipped {count} unsafe links"),
-            };
-            (
-                Some(summary.dest_dir),
-                format!(
-                    "Extracted {} {noun} to \"{name}\"{link_note}",
-                    summary.completed
-                ),
-            )
-        }
-        Err(ExtractError::PasswordRequired) => {
-            password_prompt = Some(ArchivePasswordPrompt::Required);
-            (None, String::new())
-        }
-        Err(ExtractError::BadPassword) => {
-            password_prompt = Some(ArchivePasswordPrompt::BadPassword);
-            (None, String::new())
-        }
-        Err(error) => {
-            let name = request
-                .archive_path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or("archive");
-            (None, format!("Cannot extract \"{name}\" — {error}"))
-        }
+                "archives"
+            }
+        ))
+    } else {
+        single_status
+            .or(single_error_status)
+            .or_else(|| Some(request.batch.status()))
     };
-
-    let _ = result_tx.send(JobResult::ArchiveExtract(ArchiveExtractBuild {
-        token: request.token,
-        completed,
-        total,
-        done: true,
-        dest_dir,
-        status: (!status.is_empty()).then_some(status),
-        password_prompt,
-    }));
+    let dest_dir = request.batch.reselect_path();
+    send_extract_done(
+        result_tx,
+        ArchiveExtractBuild {
+            token: request.token,
+            completed: request.batch.finished_archives(),
+            total: Some(request.batch.total_archives),
+            done: true,
+            dest_dir,
+            status,
+            password_prompt: None,
+            password_request: None,
+        },
+    );
 }
 
 fn send_extract_progress(
@@ -245,6 +302,11 @@ fn send_extract_progress(
             dest_dir: None,
             status: None,
             password_prompt: None,
+            password_request: None,
         }))
         .is_ok()
+}
+
+fn send_extract_done(result_tx: &mpsc::Sender<JobResult>, build: ArchiveExtractBuild) {
+    let _ = result_tx.send(JobResult::ArchiveExtract(build));
 }

--- a/src/app/jobs/types.rs
+++ b/src/app/jobs/types.rs
@@ -279,10 +279,90 @@ pub(in crate::app) struct ArchiveCreateBuild {
 }
 
 #[derive(Clone, Debug)]
+pub(in crate::app) struct ArchiveExtractBatchState {
+    pub(in crate::app) total_archives: usize,
+    pub(in crate::app) completed_archives: usize,
+    pub(in crate::app) failed_archives: usize,
+    pub(in crate::app) skipped_archives: usize,
+    pub(in crate::app) skipped_non_archives: usize,
+    pub(in crate::app) dest_dirs: Vec<PathBuf>,
+}
+
+impl ArchiveExtractBatchState {
+    pub(in crate::app) fn new(total_archives: usize, skipped_non_archives: usize) -> Self {
+        Self {
+            total_archives,
+            completed_archives: 0,
+            failed_archives: 0,
+            skipped_archives: 0,
+            skipped_non_archives,
+            dest_dirs: Vec::new(),
+        }
+    }
+
+    pub(in crate::app) fn finished_archives(&self) -> usize {
+        self.completed_archives + self.failed_archives + self.skipped_archives
+    }
+
+    pub(in crate::app) fn is_single_archive(&self) -> bool {
+        self.total_archives == 1 && self.skipped_non_archives == 0
+    }
+
+    pub(in crate::app) fn reselect_path(&self) -> Option<PathBuf> {
+        self.is_single_archive()
+            .then(|| self.dest_dirs.first().cloned())
+            .flatten()
+    }
+
+    pub(in crate::app) fn status(&self) -> String {
+        if self.is_single_archive()
+            && self.completed_archives == 1
+            && let Some(dest_dir) = self.dest_dirs.first()
+        {
+            let name = dest_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("folder");
+            return format!("Extracted 1 archive to \"{name}\"");
+        }
+
+        let mut parts = Vec::new();
+        parts.push(format!(
+            "Extracted {} {}",
+            self.completed_archives,
+            if self.completed_archives == 1 {
+                "archive"
+            } else {
+                "archives"
+            }
+        ));
+        if self.failed_archives > 0 {
+            parts.push(format!("{} failed", self.failed_archives));
+        }
+        if self.skipped_archives > 0 {
+            parts.push(format!("{} skipped", self.skipped_archives));
+        }
+        if self.skipped_non_archives > 0 {
+            parts.push(format!(
+                "skipped {} {}",
+                self.skipped_non_archives,
+                if self.skipped_non_archives == 1 {
+                    "non-archive"
+                } else {
+                    "non-archives"
+                }
+            ));
+        }
+        parts.join(", ")
+    }
+}
+
+#[derive(Clone, Debug)]
 pub(in crate::app) struct ArchiveExtractRequest {
     pub(in crate::app) token: u64,
-    pub(in crate::app) archive_path: PathBuf,
+    pub(in crate::app) archives: Vec<PathBuf>,
     pub(in crate::app) password: Option<crate::archive::ArchivePassword>,
+    pub(in crate::app) batch: ArchiveExtractBatchState,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -304,6 +384,8 @@ pub(in crate::app) struct ArchiveExtractBuild {
     pub(in crate::app) status: Option<String>,
     /// Populated only when `done = true` and extraction needs password input.
     pub(in crate::app) password_prompt: Option<ArchivePasswordPrompt>,
+    /// Remaining batch to resume after password input.
+    pub(in crate::app) password_request: Option<ArchiveExtractRequest>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -21,7 +21,8 @@ mod types;
 #[cfg(test)]
 use self::jobs::SchedulerMetricsSnapshot;
 use self::jobs::{
-    ArchiveExtractRequest, PreviewLineCountRequest, PreviewPriority, PreviewRequest, SearchRequest,
+    ArchiveExtractBatchState, ArchiveExtractRequest, PreviewLineCountRequest, PreviewPriority,
+    PreviewRequest, SearchRequest,
 };
 use self::{constants::*, state::*};
 use anyhow::Result;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::{Context, Result};
 
 use super::{
-    jobs::JobScheduler,
+    jobs::{ArchiveExtractRequest, JobScheduler},
     overlays::{comic, epub, images, inline_image, pdf},
     types::*,
 };
@@ -176,7 +176,7 @@ pub(super) struct ArchiveCreateOverlay {
 
 #[derive(Clone, Debug)]
 pub(super) enum ArchivePasswordPurpose {
-    Extract { archive_path: PathBuf },
+    Extract { request: ArchiveExtractRequest },
     Create,
 }
 
@@ -732,7 +732,7 @@ pub(in crate::app) struct JobRuntime {
     pub(in crate::app) archive_extract_token: u64,
     pub(in crate::app) archive_extract_progress: Option<ArchiveExtractProgress>,
     pub(in crate::app) archive_extract_source_cwd: Option<PathBuf>,
-    pub(in crate::app) archive_extract_path: Option<PathBuf>,
+    pub(in crate::app) archive_extract_request: Option<ArchiveExtractRequest>,
     pub(in crate::app) paste_token: u64,
     pub(in crate::app) paste_progress: Option<PasteProgress>,
     pub(in crate::app) queued_pastes: VecDeque<QueuedPaste>,
@@ -923,7 +923,7 @@ impl App {
                 archive_extract_token: 0,
                 archive_extract_progress: None,
                 archive_extract_source_cwd: None,
-                archive_extract_path: None,
+                archive_extract_request: None,
                 paste_token: 0,
                 paste_progress: None,
                 queued_pastes: VecDeque::new(),


### PR DESCRIPTION
## Summary

Add bulk archive extraction for selected archives.

Selected archives are extracted as one background task. Mixed selections skip non-archives, password-protected archives prompt when reached, and existing destination folders use unique sibling names.

Refs #241.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed