### PR TITLE
fix(preview): use Kitty direct graphics for Kitty/Ghostty in Zellij

### DIFF
--- a/src/app/overlays/inline_image/protocol.rs
+++ b/src/app/overlays/inline_image/protocol.rs
@@ -282,7 +282,30 @@ pub(in crate::app) fn select_image_protocol(
     identity: TerminalIdentity,
     image_previews_override: bool,
 ) -> ImageProtocol {
+    // Start of Zellij compatibility gate.
+    select_image_protocol_with_zellij(
+        identity,
+        image_previews_override,
+        env::var_os("ZELLIJ").is_some(),
+    )
+}
+
+fn select_image_protocol_with_zellij(
+    identity: TerminalIdentity,
+    image_previews_override: bool,
+    in_zellij: bool,
+) -> ImageProtocol {
     match identity {
+        // Zellij currently implements direct Kitty graphics, but not the Unicode
+        // placeholder extension used by elio's Kitty/Ghostty path. Use direct
+        // placement inside Zellij so previews target the supported protocol subset.
+        //
+        // If Zellij later adds placeholder support, remove this block to let
+        // Kitty/Ghostty inside Zellij fall through to `KittyGraphics`.
+        TerminalIdentity::Kitty | TerminalIdentity::Ghostty if in_zellij => {
+            ImageProtocol::KittyDirectGraphics
+        }
+        // End of Zellij compatibility gate.
         TerminalIdentity::Kitty => ImageProtocol::KittyGraphics,
         TerminalIdentity::Ghostty => ImageProtocol::KittyGraphics,
         // Warp implements the basic Kitty Graphics transmit-and-place protocol

--- a/src/app/overlays/inline_image/protocol/tests.rs
+++ b/src/app/overlays/inline_image/protocol/tests.rs
@@ -44,6 +44,7 @@ impl TerminalEnvGuard {
             "KONSOLE_DBUS_SERVICE",
             "KONSOLE_DBUS_WINDOW",
             "TMUX",
+            "ZELLIJ",
         ];
 
         let saved = VARS
@@ -108,6 +109,33 @@ fn select_image_protocol_ghostty_always_enabled() {
     );
     assert_eq!(
         select_image_protocol(TerminalIdentity::Ghostty, true),
+        ImageProtocol::KittyGraphics
+    );
+}
+
+#[test]
+fn select_image_protocol_uses_direct_kitty_graphics_inside_zellij() {
+    // Mirrors the Zellij compatibility gate in protocol.rs. If Zellij later
+    // supports Kitty Unicode placeholders, this is the test pair to revisit
+    // before removing the direct-path override.
+    assert_eq!(
+        select_image_protocol_with_zellij(TerminalIdentity::Kitty, false, true),
+        ImageProtocol::KittyDirectGraphics
+    );
+    assert_eq!(
+        select_image_protocol_with_zellij(TerminalIdentity::Ghostty, false, true),
+        ImageProtocol::KittyDirectGraphics
+    );
+}
+
+#[test]
+fn select_image_protocol_keeps_normal_kitty_graphics_outside_zellij() {
+    assert_eq!(
+        select_image_protocol_with_zellij(TerminalIdentity::Kitty, false, false),
+        ImageProtocol::KittyGraphics
+    );
+    assert_eq!(
+        select_image_protocol_with_zellij(TerminalIdentity::Ghostty, false, false),
         ImageProtocol::KittyGraphics
     );
 }


### PR DESCRIPTION
## Summary

Route Kitty and Ghostty through elio's Kitty direct graphics path when running inside Zellij.

Zellij's current Kitty graphics implementation supports direct placement, but not the Unicode placeholder path elio normally uses for Kitty/Ghostty. This keeps native Kitty/Ghostty behavior unchanged outside Zellij while using the supported protocol subset inside Zellij.

Follow-up to #85.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

Manual checks:

- Tested Zellij built from source with Kitty, Ghostty, Konsole, Warp, and Foot.
- Confirmed Kitty/Ghostty use `KittyDirectGraphics` inside Zellij and keep `KittyGraphics` outside Zellij.
- Confirmed Konsole, Warp, and Foot behavior is unchanged.