### PR TITLE
fix(preview): use Kitty direct graphics for WezTerm in Zellij

### DIFF
--- a/src/app/overlays/inline_image/protocol.rs
+++ b/src/app/overlays/inline_image/protocol.rs
@@ -282,7 +282,6 @@ pub(in crate::app) fn select_image_protocol(
     identity: TerminalIdentity,
     image_previews_override: bool,
 ) -> ImageProtocol {
-    // Start of Zellij compatibility gate.
     select_image_protocol_with_zellij(
         identity,
         image_previews_override,
@@ -296,22 +295,19 @@ fn select_image_protocol_with_zellij(
     in_zellij: bool,
 ) -> ImageProtocol {
     match identity {
-        // Zellij currently implements direct Kitty graphics, but not the Unicode
-        // placeholder extension used by elio's Kitty/Ghostty path. Use direct
-        // placement inside Zellij so previews target the supported protocol subset.
-        //
+        // Zellij currently implements Kitty graphics, but not Unicode placeholders.
         // If Zellij later adds placeholder support, remove this block to let
         // Kitty/Ghostty inside Zellij fall through to `KittyGraphics`.
         TerminalIdentity::Kitty | TerminalIdentity::Ghostty if in_zellij => {
             ImageProtocol::KittyDirectGraphics
         }
-        // End of Zellij compatibility gate.
+        // Use Kitty direct placement inside Zellij since it does not support iTerm inline.
+        TerminalIdentity::WezTerm if in_zellij => ImageProtocol::KittyDirectGraphics,
+
         TerminalIdentity::Kitty => ImageProtocol::KittyGraphics,
         TerminalIdentity::Ghostty => ImageProtocol::KittyGraphics,
-        // Warp implements the basic Kitty Graphics transmit-and-place protocol
-        // but not the Unicode placeholder extension that the `KittyGraphics`
-        // path emits (`U=1`). Route Warp through `KittyDirectGraphics`, which uses
-        // direct CSI cursor placement and matches what Warp actually renders.
+        // Warp supports direct Kitty graphics, but not Unicode placeholders.
+        // Use Kitty direct placement instead of elio's `KittyGraphics` path.
         TerminalIdentity::Warp => ImageProtocol::KittyDirectGraphics,
         TerminalIdentity::Konsole => ImageProtocol::KittyDirectGraphics,
         TerminalIdentity::WezTerm | TerminalIdentity::ITerm2 => ImageProtocol::ItermInline,

--- a/src/app/overlays/inline_image/protocol/tests.rs
+++ b/src/app/overlays/inline_image/protocol/tests.rs
@@ -129,6 +129,14 @@ fn select_image_protocol_uses_direct_kitty_graphics_inside_zellij() {
 }
 
 #[test]
+fn select_image_protocol_uses_direct_kitty_graphics_for_wezterm_inside_zellij() {
+    assert_eq!(
+        select_image_protocol_with_zellij(TerminalIdentity::WezTerm, false, true),
+        ImageProtocol::KittyDirectGraphics
+    );
+}
+
+#[test]
 fn select_image_protocol_keeps_normal_kitty_graphics_outside_zellij() {
     assert_eq!(
         select_image_protocol_with_zellij(TerminalIdentity::Kitty, false, false),


### PR DESCRIPTION
## Summary

Route WezTerm through elio's Kitty direct graphics path inside Zellij.

In WezTerm, elio normally uses iTerm inline images. Zellij now supports Kitty direct placement, so this uses the Kitty path inside Zellij while keeping native WezTerm behavior unchanged outside Zellij.

Follow-up to #263.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

Manual checks:

- Tested Zellij built from source inside WezTerm.
- Confirmed WezTerm uses `KittyDirectGraphics` inside Zellij and `ItermInline` outside Zellij.
- Confirmed visual previews render as expected.