### PR TITLE
fix(chooser): enter folders or choose files on double-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed preview scroll defaults from `[` / `]` to `Shift+arrows`; `H/J/K/L` remain unchanged.
+- Changed chooser-mode double-clicks to enter folders and choose files.
 
 ### Fixed
 

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -126,18 +126,18 @@ impl App {
                     .find(|hit| rect_contains(hit.rect, mouse.column, mouse.row))
                     .cloned()
                 {
-                    let Some(path) = self
+                    let Some((path, is_dir)) = self
                         .navigation
                         .entries
                         .get(hit.index)
-                        .map(|entry| entry.path.clone())
+                        .map(|entry| (entry.path.clone(), entry.is_dir()))
                     else {
                         return Ok(());
                     };
                     self.remember_drag_candidate(path.clone());
                     self.select_index(hit.index);
                     if self.is_double_click(&path) {
-                        if self.chooser_mode {
+                        if self.chooser_mode && !is_dir {
                             self.confirm_chooser_path(&path);
                         } else {
                             self.open_entry_at_index(hit.index)?;

--- a/src/app/input/tests/mouse.rs
+++ b/src/app/input/tests/mouse.rs
@@ -152,3 +152,76 @@ fn double_click_enters_clicked_directory_not_multi_selection() {
 
     fs::remove_dir_all(root).ok();
 }
+
+#[test]
+fn chooser_double_click_confirms_clicked_file() {
+    let root = temp_path("chooser-mouse-double-click-file");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let alpha = root.join("alpha.txt");
+    let beta = root.join("beta.txt");
+    fs::write(&alpha, "alpha").expect("failed to write alpha");
+    fs::write(&beta, "beta").expect("failed to write beta");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.navigation.selected_paths.insert(alpha);
+    app.enable_chooser_mode();
+    let beta_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == beta)
+        .expect("beta should be visible");
+    app.set_frame_state(FrameState {
+        entry_hits: vec![entry_hit(beta_index, 1)],
+        ..FrameState::default()
+    });
+
+    app.handle_event(left_click(1, 1))
+        .expect("first click should focus clicked file");
+    assert_eq!(app.chooser_exit, None);
+
+    app.handle_event(left_click(1, 1))
+        .expect("second click should choose clicked file");
+
+    assert!(app.should_quit);
+    assert_eq!(
+        app.chooser_exit.as_ref(),
+        Some(&ChooserExit::Confirmed(vec![beta]))
+    );
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn chooser_double_click_enters_clicked_directory() {
+    let root = temp_path("chooser-mouse-double-click-directory");
+    let child = root.join("child");
+    fs::create_dir_all(&child).expect("failed to create child directory");
+
+    let mut app = App::new_at(root.clone()).expect("failed to create app");
+    wait_for_directory_load(&mut app);
+    app.enable_chooser_mode();
+    let child_index = app
+        .navigation
+        .entries
+        .iter()
+        .position(|entry| entry.path == child)
+        .expect("child should be visible");
+    app.set_frame_state(FrameState {
+        entry_hits: vec![entry_hit(child_index, 1)],
+        ..FrameState::default()
+    });
+
+    app.handle_event(left_click(1, 1))
+        .expect("first click should focus clicked directory");
+    app.handle_event(left_click(1, 1))
+        .expect("second click should enter clicked directory");
+    wait_for_directory_load(&mut app);
+
+    assert_eq!(app.navigation.cwd, child);
+    assert!(!app.should_quit);
+    assert_eq!(app.chooser_exit, None);
+
+    fs::remove_dir_all(root).ok();
+}

--- a/src/ui/overlay_manager/help.rs
+++ b/src/ui/overlay_manager/help.rs
@@ -76,7 +76,7 @@ pub(super) fn render_help(
         e(
             "Double-click",
             if mode.is_chooser() {
-                "confirm clicked item"
+                "enter folder / choose file"
             } else {
                 "open item"
             },


### PR DESCRIPTION
## Summary

Make chooser-mode double-clicks enter folders and choose files.

Previously, double-clicking any item in chooser mode confirmed it.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed