### PR TITLE
fix(preview): fit Kitty placeholders to image aspect ratios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed image previews bleeding through archive creation popups in transparent themes.
 - Fixed image previews disappearing after returning from actions that suspend and restore the TUI.
 - Fixed pasted text being handled as normal keystrokes.
+- Fixed stretched image previews in Kitty graphics environments that do not preserve placeholder aspect ratios. ([#267])
 
 ## [1.11.2] - 2026-07-22
 
@@ -327,6 +328,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/elio-fm/elio/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/elio-fm/elio/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/elio-fm/elio/releases/tag/v1.0.0
+[#267]: https://github.com/elio-fm/elio/issues/267
 [#258]: https://github.com/elio-fm/elio/issues/258
 [#251]: https://github.com/elio-fm/elio/issues/251
 [#241]: https://github.com/elio-fm/elio/issues/241

--- a/src/app/overlays/images/present.rs
+++ b/src/app/overlays/images/present.rs
@@ -247,19 +247,15 @@ impl App {
         dimensions: RenderedImageDimensions,
         window_size: TerminalWindowSize,
     ) -> Rect {
-        // Kitty unicode placeholders fill the entire cell area and let the
-        // terminal handle scaling, so no fitting is needed. Konsole direct
-        // placements, iTerm2, and Sixel all need a cell area that already
-        // matches the image's aspect ratio.
-        if self.preview.terminal_images.protocol == ImageProtocol::KittyGraphics {
-            request.area
-        } else {
-            fit_image_area(
-                request.area,
-                window_size,
-                dimensions.width_px as f32 / dimensions.height_px as f32,
-            )
-        }
+        // Fit the placeholder grid as well as direct raster placements. Native
+        // Kitty can preserve aspect ratio within an arbitrary grid, but an
+        // aspect-correct grid also survives graphics proxies that materialize
+        // Unicode placeholders as a direct placement.
+        fit_image_area(
+            request.area,
+            window_size,
+            dimensions.width_px as f32 / dimensions.height_px as f32,
+        )
     }
 
     /// Place a static image using the active protocol.

--- a/src/app/overlays/pdf/tests/static_images/protocols.rs
+++ b/src/app/overlays/pdf/tests/static_images/protocols.rs
@@ -38,22 +38,28 @@ fn current_extensionless_png_uses_direct_kitty_source_overlay() {
 }
 
 #[test]
-fn prepared_full_pane_image_uses_full_pane_kitty_placement() {
+fn prepared_full_pane_image_uses_aspect_fitted_kitty_placement() {
     let root = temp_root("image-placement-from-rendered-png");
     fs::create_dir_all(&root).expect("failed to create temp root");
     let mut app = App::new_at(root.clone()).expect("app should initialize");
     app.preview.terminal_images.protocol = ImageProtocol::KittyGraphics;
     app.preview.terminal_images.window = Some(TerminalWindowSize {
-        cells_width: 100,
-        cells_height: 50,
-        pixels_width: 1000,
-        pixels_height: 1000,
+        cells_width: 73,
+        cells_height: 52,
+        pixels_width: 657,
+        pixels_height: 936,
     });
     app.preview.pdf.pdf_tools_available = true;
 
     let path = root.join("photo.jpg");
     write_test_raster_image(&path, ImageFormat::Jpeg, 1600, 900);
     set_single_test_entry(&mut app, &path);
+    app.input.frame_state.preview_content_area = Some(Rect {
+        x: 46,
+        y: 2,
+        width: 25,
+        height: 48,
+    });
     app.refresh_preview();
 
     let request = app
@@ -61,7 +67,7 @@ fn prepared_full_pane_image_uses_full_pane_kitty_placement() {
         .expect("image request should be available");
     let metadata = fs::metadata(&path).expect("image metadata should exist");
     let rendered = root.join("photo-rendered.png");
-    write_test_raster_image(&rendered, ImageFormat::Png, 250, 540);
+    write_test_raster_image(&rendered, ImageFormat::Png, 1024, 1024);
 
     let dirty = app.apply_image_prepare_build(crate::app::jobs::ImagePrepareBuild {
         path: path.clone(),
@@ -75,8 +81,8 @@ fn prepared_full_pane_image_uses_full_pane_kitty_placement() {
         result: Some(crate::app::overlays::images::PreparedStaticImageAsset {
             display_path: rendered,
             dimensions: RenderedImageDimensions {
-                width_px: 250,
-                height_px: 540,
+                width_px: 1024,
+                height_px: 1024,
             },
             inline_payload: None,
             sixel_dcs: None,
@@ -93,8 +99,10 @@ fn prepared_full_pane_image_uses_full_pane_kitty_placement() {
             .expect("presenting prepared jpeg overlay should not fail"),
     )
     .expect("kitty output should be utf8");
-    assert!(output.contains(&format!("c={}", request.area.width)));
-    assert!(output.contains(&format!("r={}", request.area.height)));
+    assert!(output.contains("c=25"));
+    assert!(output.contains("r=13"));
+    assert!(output.contains("\x1b[20;47H"));
+    assert_eq!(app.displayed_static_image_clear_area(), Some(request.area));
 
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }


### PR DESCRIPTION
## Summary

Fit Kitty Unicode placeholder grids to each image aspect ratio before placement.

Native Kitty preserves image aspect ratios within arbitrary placeholder grids, but some Kitty graphics implementations, such as Herdr, materialize the grid as a direct placement and stretch the image. Elio now uses its existing aspect-fit geometry for placeholder grids while retaining the full preview area for clearing.

Closes #267.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

Manual checks:

- Tested native Kitty and Kitty with tmux and Zellij.
- Tested Herdr with Kitty, Konsole, WezTerm, and Ghostty.
- Confirmed image previews retain their aspect ratio in all cases.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed