### PR TITLE
fix(elevation): preserve invoking user context on Unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a configurable `fullscreen_preview` (`P`) shortcut to temporarily expand the preview pane.
 - Added bulk archive extraction for selected archives. ([#241])
 - Added a Nord example theme. ([#270])
+- Added invoking-user-aware `sudo` and `doas` sessions on Unix: elio retains elevated filesystem access while using the invoking user's config, Places, shell, applications, editor, zoxide, and Trash/Restore; direct-root sessions continue using root's state.
 
 ### Changed
 

--- a/src/app/actions/goto.rs
+++ b/src/app/actions/goto.rs
@@ -249,7 +249,7 @@ fn trash_destination(app: &App) -> Option<PathBuf> {
         .filter_map(|row| row.item())
         .find(|item| item.kind == SidebarItemKind::Trash)
         .map(|item| item.path.clone())
-        .or_else(|| crate::fs::home_dir().and_then(|home| trash_dir(&home)))
+        .or_else(|| crate::config::trash_home_dir().and_then(|home| trash_dir(&home)))
 }
 
 #[cfg(test)]

--- a/src/app/actions/goto.rs
+++ b/src/app/actions/goto.rs
@@ -184,7 +184,7 @@ fn builtin_goto_destination(
         ),
         BuiltinGoto::Home => (
             "home",
-            crate::fs::home_dir()
+            crate::config::invoking_user_home_dir()
                 .map(GoToDestination::Path)
                 .unwrap_or_else(|| GoToDestination::Missing("Home not available".to_string())),
         ),
@@ -230,7 +230,6 @@ fn downloads_destination(app: &App) -> Option<PathBuf> {
         .filter_map(|row| row.item())
         .find(|item| item.kind == SidebarItemKind::Downloads)
         .map(|item| item.path.clone())
-        .or_else(|| crate::fs::home_dir().map(|home| home.join("Downloads")))
         .filter(|path| path.exists())
 }
 

--- a/src/app/create/editor_bulk_rename.rs
+++ b/src/app/create/editor_bulk_rename.rs
@@ -56,7 +56,7 @@ impl App {
         }
 
         let context = crate::config::invoking_user_context();
-        let invoking_user = editor_temp_owner(&context)?;
+        let invoking_user = editor_temp_owner(context)?;
         let expected_temp_owner = invoking_user.map(|(uid, _)| uid);
         let temp_path = create_temp_file(&rows, invoking_user)?;
         let (program, mut args) = editor_command();

--- a/src/app/create/editor_bulk_rename.rs
+++ b/src/app/create/editor_bulk_rename.rs
@@ -9,14 +9,21 @@ use crate::fs::rect_contains;
 use anyhow::Context;
 use anyhow::{Result, bail};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-#[cfg(unix)]
-use std::env;
 use std::{
     collections::HashSet,
     fs,
     path::{Component, Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
+#[cfg(unix)]
+use std::{
+    env,
+    io::{Read, Write},
+    os::unix::{fs::OpenOptionsExt, io::AsRawFd},
+};
+
+#[cfg(unix)]
+const MAX_EDITOR_RENAME_BYTES: u64 = 1024 * 1024;
 
 impl App {
     #[cfg(unix)]
@@ -48,7 +55,10 @@ impl App {
             );
         }
 
-        let temp_path = create_temp_file(&rows)?;
+        let context = crate::config::invoking_user_context();
+        let invoking_user = editor_temp_owner(&context)?;
+        let expected_temp_owner = invoking_user.map(|(uid, _)| uid);
+        let temp_path = create_temp_file(&rows, invoking_user)?;
         let (program, mut args) = editor_command();
         args.push(temp_path.to_string_lossy().into_owned());
 
@@ -59,6 +69,7 @@ impl App {
             session: BulkRenameEditorSession {
                 root,
                 temp_path,
+                expected_temp_owner,
                 items: selected_paths
                     .into_iter()
                     .map(bulk_rename_item_from_path)
@@ -84,6 +95,7 @@ impl App {
         let BulkRenameEditorSession {
             root,
             temp_path,
+            expected_temp_owner,
             items,
         } = session;
 
@@ -104,7 +116,7 @@ impl App {
                 }
             }
 
-            let edited = fs::read_to_string(&temp_path)
+            let edited = read_editor_rename_file(&temp_path, expected_temp_owner)
                 .with_context(|| format!("failed to read {}", temp_path.display()))?;
             let mut new_rows: Vec<String> = edited.lines().map(str::to_owned).collect();
             if edited.ends_with('\n') && new_rows.last().is_some_and(String::is_empty) {
@@ -751,8 +763,29 @@ fn common_root(paths: &[PathBuf]) -> PathBuf {
 }
 
 #[cfg(unix)]
-fn create_temp_file(rows: &[String]) -> Result<PathBuf> {
-    let base = env::temp_dir();
+fn editor_temp_owner(
+    context: &crate::config::InvocationContext,
+) -> Result<Option<(libc::uid_t, libc::gid_t)>> {
+    match context {
+        crate::config::InvocationContext::Normal
+        | crate::config::InvocationContext::RootSession => Ok(None),
+        crate::config::InvocationContext::Elevated(user) => Ok(Some((user.uid, user.gid))),
+        crate::config::InvocationContext::ElevatedUnresolved => {
+            bail!("could not resolve invoking user")
+        }
+    }
+}
+
+#[cfg(unix)]
+fn create_temp_file(
+    rows: &[String],
+    invoking_user: Option<(libc::uid_t, libc::gid_t)>,
+) -> Result<PathBuf> {
+    let base = if invoking_user.is_some() {
+        PathBuf::from("/tmp")
+    } else {
+        env::temp_dir()
+    };
     for attempt in 0..1000u32 {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -762,15 +795,31 @@ fn create_temp_file(rows: &[String]) -> Result<PathBuf> {
             "elio-bulk-rename-{}-{now}-{attempt}.txt",
             std::process::id()
         ));
-        match fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)
-        {
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        if invoking_user.is_some() {
+            options.mode(0o600);
+        }
+        match options.open(&path) {
             Ok(mut file) => {
-                use std::io::Write;
-                file.write_all(rows.join("\n").as_bytes())?;
-                file.write_all(b"\n")?;
+                let result = (|| -> Result<()> {
+                    file.write_all(rows.join("\n").as_bytes())?;
+                    file.write_all(b"\n")?;
+                    if let Some((uid, gid)) = invoking_user {
+                        if unsafe { libc::fchmod(file.as_raw_fd(), 0o600) } != 0 {
+                            return Err(std::io::Error::last_os_error().into());
+                        }
+                        if unsafe { libc::fchown(file.as_raw_fd(), uid, gid) } != 0 {
+                            return Err(std::io::Error::last_os_error().into());
+                        }
+                    }
+                    Ok(())
+                })();
+                if let Err(error) = result {
+                    drop(file);
+                    let _ = fs::remove_file(&path);
+                    return Err(error);
+                }
                 return Ok(path);
             }
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
@@ -781,9 +830,46 @@ fn create_temp_file(rows: &[String]) -> Result<PathBuf> {
 }
 
 #[cfg(unix)]
+fn read_editor_rename_file(path: &Path, expected_owner: Option<libc::uid_t>) -> Result<String> {
+    let Some(expected_owner) = expected_owner else {
+        return Ok(fs::read_to_string(path)?);
+    };
+
+    use std::os::unix::fs::MetadataExt;
+
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        bail!("edited rename document is not a regular file");
+    }
+    if metadata.uid() != expected_owner {
+        bail!("edited rename document has unexpected owner");
+    }
+    if metadata.mode() & 0o022 != 0 {
+        bail!("edited rename document is writable by another user");
+    }
+    if metadata.len() > MAX_EDITOR_RENAME_BYTES {
+        bail!("edited rename document is too large");
+    }
+
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_EDITOR_RENAME_BYTES + 1)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_EDITOR_RENAME_BYTES {
+        bail!("edited rename document is too large");
+    }
+    String::from_utf8(bytes).context("edited rename document is not valid UTF-8")
+}
+
+#[cfg(unix)]
 fn editor_command() -> (String, Vec<String>) {
     for key in ["VISUAL", "EDITOR"] {
-        if let Some(value) = env::var_os(key).and_then(|value| value.into_string().ok()) {
+        if let Some(value) =
+            crate::config::invoking_user_env_var(key).and_then(|value| value.into_string().ok())
+        {
             let tokens = crate::app::open_rules::tokenize_command(&value);
             if let Some((program, args)) = split_program_args(tokens) {
                 return (program, args);
@@ -810,6 +896,95 @@ mod tests {
             original_name: path_name(path),
             is_dir,
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unresolved_elevation_cannot_prepare_editor_document() {
+        assert!(editor_temp_owner(&crate::config::InvocationContext::ElevatedUnresolved).is_err());
+        assert!(
+            editor_temp_owner(&crate::config::InvocationContext::Normal)
+                .expect("normal session should be accepted")
+                .is_none()
+        );
+        assert!(
+            editor_temp_owner(&crate::config::InvocationContext::RootSession)
+                .expect("root session should be accepted")
+                .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invoking_user_editor_document_is_private_and_readable() {
+        use std::os::unix::fs::MetadataExt;
+
+        let uid = unsafe { libc::getuid() };
+        let gid = unsafe { libc::getgid() };
+        let path = create_temp_file(&["alpha.txt".to_string()], Some((uid, gid)))
+            .expect("failed to create invoking-user editor document");
+        let metadata = fs::metadata(&path).expect("failed to stat editor document");
+
+        assert!(path.is_absolute());
+        assert_eq!(path.parent(), Some(Path::new("/tmp")));
+        assert_eq!(metadata.uid(), uid);
+        assert_eq!(metadata.gid(), gid);
+        assert_eq!(metadata.mode() & 0o777, 0o600);
+        assert_eq!(
+            read_editor_rename_file(&path, Some(uid)).expect("failed to read editor document"),
+            "alpha.txt\n"
+        );
+        fs::remove_file(path).expect("failed to remove editor document");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invoking_user_editor_document_accepts_atomic_save_replacement() {
+        let uid = unsafe { libc::getuid() };
+        let gid = unsafe { libc::getgid() };
+        let path = create_temp_file(&["alpha.txt".to_string()], Some((uid, gid)))
+            .expect("failed to create invoking-user editor document");
+        let replacement = path.with_extension("replacement");
+        fs::write(&replacement, "renamed.txt\n").expect("failed to write replacement document");
+        fs::rename(&replacement, &path).expect("failed to replace editor document");
+
+        assert_eq!(
+            read_editor_rename_file(&path, Some(uid)).expect("failed to read replacement document"),
+            "renamed.txt\n"
+        );
+        fs::remove_file(path).expect("failed to remove editor document");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invoking_user_editor_document_rejects_symlinks_and_oversized_files() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let uid = unsafe { libc::getuid() };
+        let gid = unsafe { libc::getgid() };
+        let path = create_temp_file(&["alpha.txt".to_string()], Some((uid, gid)))
+            .expect("failed to create invoking-user editor document");
+        let target = path.with_extension("target");
+        fs::write(&target, "renamed.txt\n").expect("failed to write symlink target");
+        fs::remove_file(&path).expect("failed to remove editor document");
+        symlink(&target, &path).expect("failed to create editor document symlink");
+        assert!(read_editor_rename_file(&path, Some(uid)).is_err());
+        fs::remove_file(&path).expect("failed to remove editor document symlink");
+        fs::remove_file(target).expect("failed to remove symlink target");
+
+        let path = create_temp_file(&["alpha.txt".to_string()], Some((uid, gid)))
+            .expect("failed to create invoking-user editor document");
+        fs::write(&path, vec![b'a'; MAX_EDITOR_RENAME_BYTES as usize + 1])
+            .expect("failed to write oversized editor document");
+        assert!(read_editor_rename_file(&path, Some(uid)).is_err());
+        fs::remove_file(path).expect("failed to remove oversized editor document");
+
+        let path = create_temp_file(&["alpha.txt".to_string()], Some((uid, gid)))
+            .expect("failed to create invoking-user editor document");
+        fs::set_permissions(&path, std::fs::Permissions::from_mode(0o622))
+            .expect("failed to make editor document world-writable");
+        assert!(read_editor_rename_file(&path, Some(uid)).is_err());
+        fs::remove_file(path).expect("failed to remove world-writable editor document");
     }
 
     #[test]

--- a/src/app/create/tests.rs
+++ b/src/app/create/tests.rs
@@ -511,6 +511,7 @@ fn invalid_editor_bulk_rename_aborts_without_review_overlay() {
     let session = BulkRenameEditorSession {
         root: root.clone(),
         temp_path: temp_file.clone(),
+        expected_temp_owner: None,
         items: vec![BulkRenameItem {
             path: file.clone(),
             original_name: "alpha.txt".to_string(),
@@ -561,6 +562,7 @@ fn finish_editor_bulk_rename_opens_confirmation_with_relative_paths() {
     let session = BulkRenameEditorSession {
         root: root.clone(),
         temp_path: temp_file.clone(),
+        expected_temp_owner: None,
         items: vec![
             BulkRenameItem {
                 path: alpha.clone(),

--- a/src/app/create/trash.rs
+++ b/src/app/create/trash.rs
@@ -16,7 +16,7 @@ impl App {
     /// Returns `true` when the current directory is *inside* a trashed folder
     /// (i.e. a subdirectory of the trash root, but not the root itself).
     pub(in crate::app) fn cwd_is_inside_trash_subfolder(&self) -> bool {
-        crate::fs::home_dir()
+        crate::config::trash_home_dir()
             .and_then(|home| crate::fs::trash_dir(&home))
             .is_some_and(|trash| {
                 self.navigation.cwd != trash && self.navigation.cwd.starts_with(&trash)
@@ -24,13 +24,13 @@ impl App {
     }
 
     pub(in crate::app) fn path_is_trash(path: &Path) -> bool {
-        crate::fs::home_dir()
+        crate::config::trash_home_dir()
             .and_then(|home| crate::fs::trash_dir(&home))
             .is_some_and(|trash| path == trash)
     }
 
     pub(in crate::app) fn path_is_inside_trash(path: &Path) -> bool {
-        crate::fs::home_dir()
+        crate::config::trash_home_dir()
             .and_then(|home| crate::fs::trash_dir(&home))
             .is_some_and(|trash| path.starts_with(&trash))
     }

--- a/src/app/input/tests/keyboard.rs
+++ b/src/app/input/tests/keyboard.rs
@@ -2536,7 +2536,11 @@ fn confirm_open_with_launch_failure_sets_status() {
         app.overlays.open_with.is_none(),
         "overlay must close even on failure"
     );
-    assert_eq!(app.status, "Failed to open with Ghost App");
+    assert!(
+        app.status.starts_with("Failed to open with Ghost App: "),
+        "spawn error should be visible: {}",
+        app.status
+    );
 
     fs::remove_dir_all(&root).ok();
 }

--- a/src/app/jobs/invoking_user_fs.rs
+++ b/src/app/jobs/invoking_user_fs.rs
@@ -5,10 +5,7 @@ use crate::{
 };
 #[cfg(unix)]
 use std::{
-    fs,
     io::Write,
-    os::unix::process::CommandExt,
-    path::Path,
     process::{Command, Stdio},
 };
 
@@ -33,39 +30,9 @@ pub(super) fn run(user: &InvokingUser, request: &Request) -> Result<Response, St
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join(","),
-        )
-        .current_dir(&user.home)
-        .env_remove("SUDO_UID")
-        .env_remove("SUDO_GID")
-        .env_remove("SUDO_USER")
-        .env_remove("DOAS_USER")
-        .env_remove("XDG_DATA_HOME")
-        .env_remove("XDG_CONFIG_HOME")
-        .env_remove("XDG_CACHE_HOME");
-    if let Some(path) = &user.xdg_data_home {
-        command.env("XDG_DATA_HOME", path);
-    }
-    if !valid_runtime_dir(std::env::var_os("XDG_RUNTIME_DIR").as_deref(), user.uid) {
-        command.env_remove("XDG_RUNTIME_DIR");
-    }
-
-    let uid = user.uid;
-    let gid = user.gid;
-    let groups = user.groups.clone();
-    unsafe {
-        command.pre_exec(move || {
-            if set_supplementary_groups(&groups) != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            if libc::setgid(gid) != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            if libc::setuid(uid) != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
+        );
+    crate::invoking_user_command::prepare(&mut command, user, Some(&user.home))
+        .map_err(|e| format!("could not prepare invoking-user helper: {e}"))?;
 
     let mut child = command
         .spawn()
@@ -98,49 +65,4 @@ pub(super) fn run(user: &InvokingUser, request: &Request) -> Result<Response, St
     }
     read_response(output.stdout.as_slice())
         .map_err(|e| format!("invalid invoking-user helper response: {e}"))
-}
-
-#[cfg(target_os = "linux")]
-unsafe fn set_supplementary_groups(groups: &[libc::gid_t]) -> libc::c_int {
-    unsafe { libc::setgroups(groups.len(), groups.as_ptr()) }
-}
-
-#[cfg(not(target_os = "linux"))]
-unsafe fn set_supplementary_groups(groups: &[libc::gid_t]) -> libc::c_int {
-    let Ok(count) = libc::c_int::try_from(groups.len()) else {
-        return -1;
-    };
-    unsafe { libc::setgroups(count, groups.as_ptr()) }
-}
-
-#[cfg(unix)]
-fn valid_runtime_dir(path: Option<&std::ffi::OsStr>, uid: libc::uid_t) -> bool {
-    use std::os::unix::fs::MetadataExt;
-    let Some(path) = path.map(Path::new).filter(|path| path.is_absolute()) else {
-        return false;
-    };
-    fs::metadata(path).is_ok_and(|metadata| metadata.is_dir() && metadata.uid() == uid)
-}
-
-#[cfg(all(test, unix))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn runtime_dir_must_be_absolute_and_user_owned() {
-        assert!(!valid_runtime_dir(
-            Some(std::ffi::OsStr::new("relative")),
-            1000
-        ));
-        assert!(!valid_runtime_dir(
-            Some(std::ffi::OsStr::new("/missing")),
-            1000
-        ));
-        let temp =
-            std::env::temp_dir().join(format!("elio-runtime-dir-test-{}", std::process::id()));
-        fs::create_dir_all(&temp).unwrap();
-        let uid = unsafe { libc::geteuid() };
-        assert!(valid_runtime_dir(Some(temp.as_os_str()), uid));
-        fs::remove_dir(&temp).unwrap();
-    }
 }

--- a/src/app/jobs/invoking_user_fs.rs
+++ b/src/app/jobs/invoking_user_fs.rs
@@ -1,0 +1,146 @@
+#[cfg(unix)]
+use crate::{
+    config::InvokingUser,
+    user_fs_helper::{Request, Response, read_response, validate_request, write_request},
+};
+#[cfg(unix)]
+use std::{
+    fs,
+    io::Write,
+    os::unix::process::CommandExt,
+    path::Path,
+    process::{Command, Stdio},
+};
+
+#[cfg(unix)]
+pub(super) fn run(user: &InvokingUser, request: &Request) -> Result<Response, String> {
+    validate_request(request).map_err(|e| format!("invalid invoking-user request: {e}"))?;
+    let mut command = Command::new(std::env::current_exe().map_err(|e| e.to_string())?);
+    command
+        .arg("--internal-user-fs-helper")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("HOME", &user.home)
+        .env("USER", &user.name)
+        .env("LOGNAME", &user.name)
+        .env("ELIO_HELPER_UID", user.uid.to_string())
+        .env("ELIO_HELPER_GID", user.gid.to_string())
+        .env(
+            "ELIO_HELPER_GROUPS",
+            user.groups
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(","),
+        )
+        .current_dir(&user.home)
+        .env_remove("SUDO_UID")
+        .env_remove("SUDO_GID")
+        .env_remove("SUDO_USER")
+        .env_remove("DOAS_USER")
+        .env_remove("XDG_DATA_HOME")
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("XDG_CACHE_HOME");
+    if let Some(path) = &user.xdg_data_home {
+        command.env("XDG_DATA_HOME", path);
+    }
+    if !valid_runtime_dir(std::env::var_os("XDG_RUNTIME_DIR").as_deref(), user.uid) {
+        command.env_remove("XDG_RUNTIME_DIR");
+    }
+
+    let uid = user.uid;
+    let gid = user.gid;
+    let groups = user.groups.clone();
+    unsafe {
+        command.pre_exec(move || {
+            if set_supplementary_groups(&groups) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::setgid(gid) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::setuid(uid) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("could not start invoking-user helper: {e}"))?;
+    let write_result = child
+        .stdin
+        .take()
+        .ok_or_else(|| "invoking-user helper has no stdin".to_string())
+        .and_then(|mut stdin| {
+            write_request(&mut stdin, request).map_err(|e| e.to_string())?;
+            stdin.flush().map_err(|e| e.to_string())
+        });
+    if let Err(error) = write_result {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(format!("could not send invoking-user request: {error}"));
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("could not wait for invoking-user helper: {e}"))?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr);
+        let detail = detail.trim();
+        return Err(if detail.is_empty() {
+            "invoking-user helper failed".to_string()
+        } else {
+            format!("invoking-user helper failed: {detail}")
+        });
+    }
+    read_response(output.stdout.as_slice())
+        .map_err(|e| format!("invalid invoking-user helper response: {e}"))
+}
+
+#[cfg(target_os = "linux")]
+unsafe fn set_supplementary_groups(groups: &[libc::gid_t]) -> libc::c_int {
+    unsafe { libc::setgroups(groups.len(), groups.as_ptr()) }
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe fn set_supplementary_groups(groups: &[libc::gid_t]) -> libc::c_int {
+    let Ok(count) = libc::c_int::try_from(groups.len()) else {
+        return -1;
+    };
+    unsafe { libc::setgroups(count, groups.as_ptr()) }
+}
+
+#[cfg(unix)]
+fn valid_runtime_dir(path: Option<&std::ffi::OsStr>, uid: libc::uid_t) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    let Some(path) = path.map(Path::new).filter(|path| path.is_absolute()) else {
+        return false;
+    };
+    fs::metadata(path).is_ok_and(|metadata| metadata.is_dir() && metadata.uid() == uid)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_dir_must_be_absolute_and_user_owned() {
+        assert!(!valid_runtime_dir(
+            Some(std::ffi::OsStr::new("relative")),
+            1000
+        ));
+        assert!(!valid_runtime_dir(
+            Some(std::ffi::OsStr::new("/missing")),
+            1000
+        ));
+        let temp =
+            std::env::temp_dir().join(format!("elio-runtime-dir-test-{}", std::process::id()));
+        fs::create_dir_all(&temp).unwrap();
+        let uid = unsafe { libc::geteuid() };
+        assert!(valid_runtime_dir(Some(temp.as_os_str()), uid));
+        fs::remove_dir(&temp).unwrap();
+    }
+}

--- a/src/app/jobs/mod.rs
+++ b/src/app/jobs/mod.rs
@@ -1,5 +1,5 @@
 mod config;
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 mod invoking_user_fs;
 mod metrics;
 mod pool;

--- a/src/app/jobs/mod.rs
+++ b/src/app/jobs/mod.rs
@@ -1,4 +1,6 @@
 mod config;
+#[cfg(all(unix, not(target_os = "macos")))]
+mod invoking_user_fs;
 mod metrics;
 mod pool;
 mod results;
@@ -11,6 +13,8 @@ mod types;
 pub(super) use self::metrics::SchedulerMetricsSnapshot;
 pub(super) use self::scheduler::JobScheduler;
 use self::sync::{lock_unpoison, wait_unpoison};
+#[cfg(unix)]
+pub(crate) use self::tasks::trash::run_user_trash_helper;
 pub(super) use self::types::{
     ArchiveCreateBuild, ArchiveCreateRequest, ArchiveExtractBatchState, ArchiveExtractBuild,
     ArchiveExtractRequest, ArchivePasswordPrompt, DirectoryBuild, DirectoryFingerprintBuild,

--- a/src/app/jobs/tasks/restore.rs
+++ b/src/app/jobs/tasks/restore.rs
@@ -220,7 +220,7 @@ fn restore_as_invoking_user(path: &std::path::Path) -> anyhow::Result<()> {
             }
             InvocationContext::Elevated(user) => {
                 let response = super::super::invoking_user_fs::run(
-                    &user,
+                    user,
                     &Request::Restore(path.to_path_buf()),
                 )
                 .map_err(anyhow::Error::msg)?;

--- a/src/app/jobs/tasks/restore.rs
+++ b/src/app/jobs/tasks/restore.rs
@@ -181,7 +181,8 @@ fn run_restore(
             break;
         }
 
-        match crate::fs::restore_trash_item(&target.path) {
+        let restore_result = restore_as_invoking_user(&target.path);
+        match restore_result {
             Ok(_) => {
                 completed += 1;
                 #[cfg(target_os = "macos")]
@@ -203,6 +204,35 @@ fn run_restore(
     }
 
     (completed, errors, stopped_early)
+}
+
+fn restore_as_invoking_user(path: &std::path::Path) -> anyhow::Result<()> {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        use crate::{
+            config::{InvocationContext, invoking_user_context},
+            user_fs_helper::Request,
+        };
+        match invoking_user_context() {
+            InvocationContext::Normal => {}
+            InvocationContext::ElevatedUnresolved => {
+                anyhow::bail!("could not resolve invoking user; nothing was restored")
+            }
+            InvocationContext::Elevated(user) => {
+                let response = super::super::invoking_user_fs::run(
+                    &user,
+                    &Request::Restore(path.to_path_buf()),
+                )
+                .map_err(anyhow::Error::msg)?;
+                if let Some(error) = response.error {
+                    anyhow::bail!(error);
+                }
+                anyhow::ensure!(response.completed == 1, "helper did not restore the item");
+                return Ok(());
+            }
+        }
+    }
+    crate::fs::restore_trash_item(path)
 }
 
 /// Send a throttled intermediate progress result.  Returns `false` if the

--- a/src/app/jobs/tasks/restore.rs
+++ b/src/app/jobs/tasks/restore.rs
@@ -238,10 +238,10 @@ fn restore_as_invoking_user(path: &std::path::Path) -> anyhow::Result<Option<Str
 fn restore_helper_response(
     response: crate::user_fs_helper::Response,
 ) -> anyhow::Result<Option<String>> {
-    match (response.completed, response.error) {
-        (1, warning) => Ok(warning),
-        (0, Some(error)) => anyhow::bail!(error),
-        (0, None) => anyhow::bail!("helper did not restore the item"),
+    match (response.completed, response.error, response.warning) {
+        (1, None, warning) => Ok(warning),
+        (0, Some(error), None) => anyhow::bail!(error),
+        (0, None, None) => anyhow::bail!("helper did not restore the item"),
         _ => anyhow::bail!("invalid invoking-user restore response"),
     }
 }
@@ -278,7 +278,8 @@ mod tests {
     fn completed_helper_restore_preserves_metadata_warning() {
         let warning = restore_helper_response(crate::user_fs_helper::Response {
             completed: 1,
-            error: Some("could not update Trash restore metadata".to_string()),
+            error: None,
+            warning: Some("could not update Trash restore metadata".to_string()),
         })
         .unwrap();
 
@@ -293,6 +294,7 @@ mod tests {
         let error = restore_helper_response(crate::user_fs_helper::Response {
             completed: 0,
             error: Some("permission denied".to_string()),
+            warning: None,
         })
         .unwrap_err();
 

--- a/src/app/jobs/tasks/restore.rs
+++ b/src/app/jobs/tasks/restore.rs
@@ -46,7 +46,7 @@ impl RestorePool {
         let worker = thread::spawn(move || {
             while let Some(request) = RestoreShared::pop(&shared_worker) {
                 RestoreShared::set_active(&shared_worker, true);
-                let (completed, errors, stopped_early) = run_restore(
+                let (completed, errors, warnings, stopped_early) = run_restore(
                     &request,
                     &result_tx,
                     &shared_worker.cancelled,
@@ -56,7 +56,7 @@ impl RestorePool {
 
                 let total = request.targets.len();
                 let single_name = (total == 1).then(|| request.targets[0].name.as_str());
-                let status = if stopped_early {
+                let mut status = if stopped_early {
                     match completed {
                         0 => "Restore cancelled".to_string(),
                         1 => "Restore cancelled — Restored 1 item".to_string(),
@@ -81,6 +81,14 @@ impl RestorePool {
                         errors[0]
                     )
                 };
+                if !warnings.is_empty() {
+                    let warning = if warnings.len() == 1 {
+                        format!("warning: {}", warnings[0])
+                    } else {
+                        format!("{} warnings — first: {}", warnings.len(), warnings[0])
+                    };
+                    status = format!("{status}; {warning}");
+                }
 
                 if result_tx
                     .send(JobResult::Restore(RestoreBuild {
@@ -165,13 +173,12 @@ fn run_restore(
     result_tx: &mpsc::Sender<JobResult>,
     cancelled: &AtomicBool,
     cancel_token: &AtomicU64,
-) -> (usize, Vec<String>, bool) {
+) -> (usize, Vec<String>, Vec<String>, bool) {
     let mut completed = 0usize;
     let mut errors: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
     let mut stopped_early = false;
     let mut last_progress_at: Option<Instant> = None;
-    #[cfg(target_os = "macos")]
-    let mut restored_names: Vec<&str> = Vec::new();
 
     for target in &request.targets {
         if cancelled.load(Ordering::Relaxed)
@@ -183,10 +190,11 @@ fn run_restore(
 
         let restore_result = restore_as_invoking_user(&target.path);
         match restore_result {
-            Ok(_) => {
+            Ok(metadata_warning) => {
                 completed += 1;
-                #[cfg(target_os = "macos")]
-                restored_names.push(target.name.as_str());
+                if let Some(warning) = metadata_warning {
+                    warnings.push(format!("Restored \"{}\", but {warning}", target.name));
+                }
             }
             Err(e) => {
                 errors.push(format!("Could not restore \"{}\": {e}", target.name));
@@ -198,16 +206,11 @@ fn run_restore(
         }
     }
 
-    #[cfg(target_os = "macos")]
-    if !restored_names.is_empty() {
-        crate::fs::remove_restore_origins(&restored_names);
-    }
-
-    (completed, errors, stopped_early)
+    (completed, errors, warnings, stopped_early)
 }
 
-fn restore_as_invoking_user(path: &std::path::Path) -> anyhow::Result<()> {
-    #[cfg(all(unix, not(target_os = "macos")))]
+fn restore_as_invoking_user(path: &std::path::Path) -> anyhow::Result<Option<String>> {
+    #[cfg(unix)]
     {
         use crate::{
             config::{InvocationContext, invoking_user_context},
@@ -224,15 +227,23 @@ fn restore_as_invoking_user(path: &std::path::Path) -> anyhow::Result<()> {
                     &Request::Restore(path.to_path_buf()),
                 )
                 .map_err(anyhow::Error::msg)?;
-                if let Some(error) = response.error {
-                    anyhow::bail!(error);
-                }
-                anyhow::ensure!(response.completed == 1, "helper did not restore the item");
-                return Ok(());
+                return restore_helper_response(response);
             }
         }
     }
-    crate::fs::restore_trash_item(path)
+    crate::fs::restore_trash_item(path).map(|()| None)
+}
+
+#[cfg(unix)]
+fn restore_helper_response(
+    response: crate::user_fs_helper::Response,
+) -> anyhow::Result<Option<String>> {
+    match (response.completed, response.error) {
+        (1, warning) => Ok(warning),
+        (0, Some(error)) => anyhow::bail!(error),
+        (0, None) => anyhow::bail!("helper did not restore the item"),
+        _ => anyhow::bail!("invalid invoking-user restore response"),
+    }
 }
 
 /// Send a throttled intermediate progress result.  Returns `false` if the
@@ -257,4 +268,34 @@ fn send_restore_progress(
             .is_ok();
     }
     true
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completed_helper_restore_preserves_metadata_warning() {
+        let warning = restore_helper_response(crate::user_fs_helper::Response {
+            completed: 1,
+            error: Some("could not update Trash restore metadata".to_string()),
+        })
+        .unwrap();
+
+        assert_eq!(
+            warning.as_deref(),
+            Some("could not update Trash restore metadata")
+        );
+    }
+
+    #[test]
+    fn failed_helper_restore_remains_an_error() {
+        let error = restore_helper_response(crate::user_fs_helper::Response {
+            completed: 0,
+            error: Some("permission denied".to_string()),
+        })
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "permission denied");
+    }
 }

--- a/src/app/jobs/tasks/restore.rs
+++ b/src/app/jobs/tasks/restore.rs
@@ -214,7 +214,7 @@ fn restore_as_invoking_user(path: &std::path::Path) -> anyhow::Result<()> {
             user_fs_helper::Request,
         };
         match invoking_user_context() {
-            InvocationContext::Normal => {}
+            InvocationContext::Normal | InvocationContext::RootSession => {}
             InvocationContext::ElevatedUnresolved => {
                 anyhow::bail!("could not resolve invoking user; nothing was restored")
             }

--- a/src/app/jobs/tasks/trash.rs
+++ b/src/app/jobs/tasks/trash.rs
@@ -544,7 +544,7 @@ fn trash_as_invoking_user(paths: &[&Path]) -> Option<(usize, Vec<String>, bool)>
     };
 
     match invoking_user_context() {
-        InvocationContext::Normal => None,
+        InvocationContext::Normal | InvocationContext::RootSession => None,
         InvocationContext::ElevatedUnresolved => Some((
             0,
             vec!["Could not resolve invoking user; nothing was trashed".to_string()],

--- a/src/app/jobs/tasks/trash.rs
+++ b/src/app/jobs/tasks/trash.rs
@@ -552,7 +552,7 @@ fn trash_as_invoking_user(paths: &[&Path]) -> Option<(usize, Vec<String>, bool)>
         )),
         InvocationContext::Elevated(user) => {
             let owned = paths.iter().map(|path| (*path).to_path_buf()).collect();
-            let response = super::super::invoking_user_fs::run(&user, &Request::Trash(owned));
+            let response = super::super::invoking_user_fs::run(user, &Request::Trash(owned));
             Some(match response {
                 Ok(response) => (
                     response.completed,

--- a/src/app/jobs/tasks/trash.rs
+++ b/src/app/jobs/tasks/trash.rs
@@ -315,9 +315,24 @@ fn run_permanent_delete(
 /// risk of a false positive from a file whose base name happens to embed the
 /// same number.  The parent dir (`cleanup/`) is on the same filesystem as the
 /// home trash so `rename(2)` never crosses a device boundary.
+fn staging_root_for(data_dir: Option<PathBuf>, effective_uid: u32) -> Option<PathBuf> {
+    if effective_uid == 0 {
+        return None;
+    }
+    data_dir.map(|dir| dir.join("elio").join("cleanup"))
+}
+
+fn staging_root() -> Option<PathBuf> {
+    #[cfg(unix)]
+    let effective_uid = unsafe { libc::geteuid() };
+    #[cfg(not(unix))]
+    let effective_uid = 1;
+    staging_root_for(dirs::data_dir(), effective_uid)
+}
+
 fn staging_dir() -> Option<PathBuf> {
     let pid = std::process::id();
-    dirs::data_dir().map(|d| d.join("elio").join("cleanup").join(pid.to_string()))
+    staging_root().map(|root| root.join(pid.to_string()))
 }
 
 /// Atomically moves `path` into `staging`, giving it a unique name.
@@ -390,7 +405,7 @@ fn run_staged_cleanup(staged: Vec<(String, PathBuf)>) -> Vec<String> {
 /// Best-effort: errors are silently ignored.
 pub(in crate::app::jobs) fn sweep_staging_on_startup() {
     let current_pid = std::process::id();
-    let Some(cleanup_root) = dirs::data_dir().map(|d| d.join("elio").join("cleanup")) else {
+    let Some(cleanup_root) = staging_root() else {
         return;
     };
     // If cleanup_root/{current_pid}/ already exists at startup it must be a

--- a/src/app/jobs/tasks/trash.rs
+++ b/src/app/jobs/tasks/trash.rs
@@ -232,12 +232,15 @@ fn run_permanent_delete(
     let mut errors: Vec<String> = Vec::new();
     let mut stopped_early = false;
     let mut last_progress_at: Option<Instant> = None;
-    // Collect names of items successfully removed from trash so their restore
-    // origins can be pruned after the loop.  Staged directories are included
-    // here even if their background cleanup later fails: the item is already
-    // gone from the trash regardless of whether the staging area is reclaimed.
     #[cfg(target_os = "macos")]
-    let mut deleted_names: Vec<&str> = Vec::new();
+    let restore_origins_trash_dir = macos_restore_origins_trash_dir();
+    // Collect names of top-level items successfully removed from the selected
+    // user's Trash so their restore origins can be pruned after the loop.
+    // Staged directories are included even if their background cleanup later
+    // fails: the item is already gone from Trash regardless of whether staging
+    // is reclaimed.
+    #[cfg(target_os = "macos")]
+    let mut deleted_names: Vec<String> = Vec::new();
 
     for target in &request.targets {
         if cancelled.load(Ordering::Relaxed)
@@ -247,7 +250,7 @@ fn run_permanent_delete(
             break;
         }
 
-        if target.is_dir {
+        let removed_from_original_location = if target.is_dir {
             // Try rename-to-staging first.  If staging is unavailable or the
             // rename fails (wrong filesystem, permissions), fall back to an
             // in-place remove_dir_all.
@@ -257,30 +260,33 @@ fn run_permanent_delete(
             {
                 Some(staged_path) => {
                     staged.push((target.name.clone(), staged_path));
-                    completed += 1;
-                    #[cfg(target_os = "macos")]
-                    deleted_names.push(target.name.as_str());
+                    true
                 }
                 None => match fs::remove_dir_all(&target.path) {
-                    Ok(()) => {
-                        completed += 1;
-                        #[cfg(target_os = "macos")]
-                        deleted_names.push(target.name.as_str());
-                    }
+                    Ok(()) => true,
                     Err(e) => {
                         errors.push(format!("Could not delete \"{}\": {e}", target.name));
+                        false
                     }
                 },
             }
         } else {
             match fs::remove_file(&target.path) {
-                Ok(()) => {
-                    completed += 1;
-                    #[cfg(target_os = "macos")]
-                    deleted_names.push(target.name.as_str());
+                Ok(()) => true,
+                Err(e) => {
+                    errors.push(format!("Could not delete \"{}\": {e}", target.name));
+                    false
                 }
-                Err(e) => errors.push(format!("Could not delete \"{}\": {e}", target.name)),
             }
+        };
+        if removed_from_original_location {
+            completed += 1;
+            #[cfg(target_os = "macos")]
+            collect_deleted_restore_origin(
+                &target.path,
+                restore_origins_trash_dir.as_deref(),
+                &mut deleted_names,
+            );
         }
 
         if !send_trash_progress(result_tx, request.token, completed, &mut last_progress_at) {
@@ -299,11 +305,59 @@ fn run_permanent_delete(
     }
 
     #[cfg(target_os = "macos")]
-    if !deleted_names.is_empty() {
-        crate::fs::remove_restore_origins(&deleted_names);
+    if let Err(error) = remove_deleted_restore_origins(&deleted_names) {
+        errors.push(format!("Could not update Trash restore metadata: {error}"));
     }
 
     (completed, errors, stopped_early)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_restore_origins_trash_dir() -> Option<PathBuf> {
+    crate::config::trash_home_dir().map(|home| home.join(".Trash"))
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn collect_deleted_restore_origin(
+    path: &Path,
+    trash_dir: Option<&Path>,
+    deleted_names: &mut Vec<String>,
+) {
+    if trash_dir.is_some_and(|trash_dir| path.parent() == Some(trash_dir))
+        && let Some(name) = path.file_name().and_then(|name| name.to_str())
+    {
+        deleted_names.push(name.to_owned());
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn remove_deleted_restore_origins(names: &[String]) -> Result<(), String> {
+    use crate::{config::InvocationContext, user_fs_helper::Request};
+
+    if names.is_empty() {
+        return Ok(());
+    }
+    match crate::config::invoking_user_context() {
+        InvocationContext::Normal | InvocationContext::RootSession => {
+            let refs = names.iter().map(String::as_str).collect::<Vec<_>>();
+            crate::fs::remove_restore_origins(&refs);
+            Ok(())
+        }
+        InvocationContext::Elevated(user) => {
+            let response = super::super::invoking_user_fs::run(
+                user,
+                &Request::RemoveRestoreOrigins(names.to_vec()),
+            )?;
+            if let Some(error) = response.error {
+                return Err(error);
+            }
+            if response.completed != names.len() {
+                return Err("helper did not remove all restore origins".to_string());
+            }
+            Ok(())
+        }
+        InvocationContext::ElevatedUnresolved => Err("could not resolve invoking user".to_string()),
+    }
 }
 
 /// Returns the path used as a staging area for rename-first directory deletion.
@@ -508,24 +562,13 @@ fn run_trash_batch(
     let paths: Vec<_> = request.targets.iter().map(|t| t.path.as_path()).collect();
     let total = paths.len();
 
-    #[cfg(all(unix, not(target_os = "macos")))]
+    #[cfg(unix)]
     if let Some(result) = trash_as_invoking_user(&paths) {
         return result;
     }
 
     match trash_with_system_backend(&paths) {
-        TrashBatchBackendResult::Completed => {
-            #[cfg(target_os = "macos")]
-            {
-                let origins: Vec<(String, std::path::PathBuf)> = request
-                    .targets
-                    .iter()
-                    .map(|t| (t.name.clone(), t.path.clone()))
-                    .collect();
-                crate::fs::save_restore_origins(&origins);
-            }
-            (total, Vec::new(), false)
-        }
+        TrashBatchBackendResult::Completed => (total, Vec::new(), false),
         TrashBatchBackendResult::Failed { completed, error } => (completed, vec![error], false),
     }
 }
@@ -536,7 +579,7 @@ enum TrashBatchBackendResult {
     Failed { completed: usize, error: String },
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 fn trash_as_invoking_user(paths: &[&Path]) -> Option<(usize, Vec<String>, bool)> {
     use crate::{
         config::{InvocationContext, invoking_user_context},
@@ -582,18 +625,30 @@ pub(crate) fn run_user_trash_helper(paths: &[PathBuf]) -> crate::user_fs_helper:
 
 fn trash_with_system_backend(paths: &[&Path]) -> TrashBatchBackendResult {
     #[cfg(target_os = "linux")]
-    {
-        trash_with_gio_first(paths)
-    }
+    let result = trash_with_gio_first(paths);
 
     #[cfg(not(target_os = "linux"))]
-    match trash_with_crate(paths) {
+    let result = match trash_with_crate(paths) {
         Ok(()) => TrashBatchBackendResult::Completed,
         Err(error) => TrashBatchBackendResult::Failed {
             completed: 0,
             error,
         },
+    };
+
+    #[cfg(target_os = "macos")]
+    if result == TrashBatchBackendResult::Completed {
+        let origins = paths
+            .iter()
+            .filter_map(|path| {
+                let name = path.file_name()?.to_str()?.to_owned();
+                Some((name, path.to_path_buf()))
+            })
+            .collect::<Vec<_>>();
+        crate::fs::save_restore_origins(&origins);
     }
+
+    result
 }
 
 fn trash_with_crate(paths: &[&Path]) -> Result<(), String> {

--- a/src/app/jobs/tasks/trash.rs
+++ b/src/app/jobs/tasks/trash.rs
@@ -11,6 +11,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(any(test, target_os = "macos"))]
+use std::{collections::HashMap, ffi::OsString};
+
 #[cfg(target_os = "linux")]
 use std::process::{Command, Stdio};
 
@@ -60,7 +63,7 @@ impl TrashPool {
         let worker = thread::spawn(move || {
             while let Some(request) = TrashShared::pop(&shared_worker) {
                 TrashShared::set_active(&shared_worker, true);
-                let (completed, errors, stopped_early) = run_trash(
+                let (completed, errors, warnings, stopped_early) = run_trash(
                     &request,
                     &result_tx,
                     &shared_worker.cancelled,
@@ -75,7 +78,7 @@ impl TrashPool {
                 };
                 let total = request.targets.len();
                 let single_name = (total == 1).then(|| request.targets[0].name.as_str());
-                let status = if stopped_early && errors.is_empty() {
+                let mut status = if stopped_early && errors.is_empty() {
                     match completed {
                         0 => "Trash cancelled".to_string(),
                         1 => format!("Trash cancelled — {verb} 1 item"),
@@ -110,6 +113,14 @@ impl TrashPool {
                         errors[0]
                     )
                 };
+                if !warnings.is_empty() {
+                    let warning = format_restore_metadata_warning(verb, completed, &warnings);
+                    status = if !stopped_early && errors.is_empty() && completed > 0 {
+                        warning
+                    } else {
+                        format!("{status}; {warning}")
+                    };
+                }
 
                 if result_tx
                     .send(JobResult::Trash(TrashBuild {
@@ -197,11 +208,32 @@ fn run_trash(
     result_tx: &mpsc::Sender<JobResult>,
     cancelled: &AtomicBool,
     cancel_token: &AtomicU64,
-) -> (usize, Vec<String>, bool) {
+) -> (usize, Vec<String>, Vec<String>, bool) {
     if request.permanent {
-        run_permanent_delete(request, result_tx, cancelled, cancel_token)
+        let (completed, errors, stopped_early) =
+            run_permanent_delete(request, result_tx, cancelled, cancel_token);
+        (completed, errors, Vec::new(), stopped_early)
     } else {
         run_trash_batch(request, cancelled, cancel_token)
+    }
+}
+
+fn format_restore_metadata_warning(verb: &str, completed: usize, warnings: &[String]) -> String {
+    let subject = match completed {
+        1 => format!("{verb} 1 item"),
+        n => format!("{verb} {n} items"),
+    };
+    if warnings.len() == 1 {
+        format!(
+            "{subject}; restore metadata could not be saved: {}",
+            warnings[0]
+        )
+    } else {
+        format!(
+            "{subject}; {} restore metadata warnings — first: {}",
+            warnings.len(),
+            warnings[0]
+        )
     }
 }
 
@@ -350,6 +382,9 @@ fn remove_deleted_restore_origins(names: &[String]) -> Result<(), String> {
             )?;
             if let Some(error) = response.error {
                 return Err(error);
+            }
+            if let Some(warning) = response.warning {
+                return Err(warning);
             }
             if response.completed != names.len() {
                 return Err("helper did not remove all restore origins".to_string());
@@ -554,9 +589,9 @@ fn run_trash_batch(
     request: &TrashRequest,
     cancelled: &AtomicBool,
     cancel_token: &AtomicU64,
-) -> (usize, Vec<String>, bool) {
+) -> (usize, Vec<String>, Vec<String>, bool) {
     if cancelled.load(Ordering::Relaxed) || cancel_token.load(Ordering::Relaxed) == request.token {
-        return (0, Vec::new(), true);
+        return (0, Vec::new(), Vec::new(), true);
     }
 
     let paths: Vec<_> = request.targets.iter().map(|t| t.path.as_path()).collect();
@@ -568,19 +603,33 @@ fn run_trash_batch(
     }
 
     match trash_with_system_backend(&paths) {
-        TrashBatchBackendResult::Completed => (total, Vec::new(), false),
-        TrashBatchBackendResult::Failed { completed, error } => (completed, vec![error], false),
+        TrashBatchBackendResult::Completed => (total, Vec::new(), Vec::new(), false),
+        #[cfg(any(test, target_os = "macos"))]
+        TrashBatchBackendResult::CompletedWithWarning { completed, warning } => {
+            (completed, Vec::new(), vec![warning], false)
+        }
+        TrashBatchBackendResult::Failed { completed, error } => {
+            (completed, vec![error], Vec::new(), false)
+        }
     }
 }
 
 #[derive(Debug, Eq, PartialEq)]
 enum TrashBatchBackendResult {
     Completed,
-    Failed { completed: usize, error: String },
+    #[cfg(any(test, target_os = "macos"))]
+    CompletedWithWarning {
+        completed: usize,
+        warning: String,
+    },
+    Failed {
+        completed: usize,
+        error: String,
+    },
 }
 
 #[cfg(unix)]
-fn trash_as_invoking_user(paths: &[&Path]) -> Option<(usize, Vec<String>, bool)> {
+fn trash_as_invoking_user(paths: &[&Path]) -> Option<(usize, Vec<String>, Vec<String>, bool)> {
     use crate::{
         config::{InvocationContext, invoking_user_context},
         user_fs_helper::Request,
@@ -591,6 +640,7 @@ fn trash_as_invoking_user(paths: &[&Path]) -> Option<(usize, Vec<String>, bool)>
         InvocationContext::ElevatedUnresolved => Some((
             0,
             vec!["Could not resolve invoking user; nothing was trashed".to_string()],
+            Vec::new(),
             false,
         )),
         InvocationContext::Elevated(user) => {
@@ -600,9 +650,15 @@ fn trash_as_invoking_user(paths: &[&Path]) -> Option<(usize, Vec<String>, bool)>
                 Ok(response) => (
                     response.completed,
                     response.error.into_iter().collect(),
+                    response.warning.into_iter().collect(),
                     false,
                 ),
-                Err(error) => (0, vec![format!("Could not trash items: {error}")], false),
+                Err(error) => (
+                    0,
+                    vec![format!("Could not trash items: {error}")],
+                    Vec::new(),
+                    false,
+                ),
             })
         }
     }
@@ -615,44 +671,207 @@ pub(crate) fn run_user_trash_helper(paths: &[PathBuf]) -> crate::user_fs_helper:
         TrashBatchBackendResult::Completed => crate::user_fs_helper::Response {
             completed: paths.len(),
             error: None,
+            warning: None,
         },
+        #[cfg(any(test, target_os = "macos"))]
+        TrashBatchBackendResult::CompletedWithWarning { completed, warning } => {
+            crate::user_fs_helper::Response {
+                completed,
+                error: None,
+                warning: Some(warning),
+            }
+        }
         TrashBatchBackendResult::Failed { completed, error } => crate::user_fs_helper::Response {
             completed,
             error: Some(error),
+            warning: None,
         },
     }
 }
 
 fn trash_with_system_backend(paths: &[&Path]) -> TrashBatchBackendResult {
     #[cfg(target_os = "linux")]
-    let result = trash_with_gio_first(paths);
-
-    #[cfg(not(target_os = "linux"))]
-    let result = match trash_with_crate(paths) {
-        Ok(()) => TrashBatchBackendResult::Completed,
-        Err(error) => TrashBatchBackendResult::Failed {
-            completed: 0,
-            error,
-        },
-    };
+    return trash_with_gio_first(paths);
 
     #[cfg(target_os = "macos")]
-    if result == TrashBatchBackendResult::Completed {
-        let origins = paths
-            .iter()
-            .filter_map(|path| {
-                let name = path.file_name()?.to_str()?.to_owned();
-                Some((name, path.to_path_buf()))
-            })
-            .collect::<Vec<_>>();
-        crate::fs::save_restore_origins(&origins);
-    }
+    return trash_with_macos_finder(paths);
 
-    result
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        match trash_with_crate(paths) {
+            Ok(()) => TrashBatchBackendResult::Completed,
+            Err(error) => TrashBatchBackendResult::Failed {
+                completed: 0,
+                error,
+            },
+        }
+    }
 }
 
 fn trash_with_crate(paths: &[&Path]) -> Result<(), String> {
     ::trash::delete_all(paths.iter().copied()).map_err(|e| e.to_string())
+}
+
+#[cfg(any(test, target_os = "macos"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct TrashEntryIdentity {
+    device: u64,
+    inode: u64,
+}
+
+#[cfg(any(test, target_os = "macos"))]
+type TrashSnapshot = HashMap<OsString, TrashEntryIdentity>;
+
+#[cfg(any(test, target_os = "macos"))]
+#[derive(Debug, Eq, PartialEq)]
+enum TrashNameCorrelationError {
+    Missing,
+    Ambiguous(usize),
+}
+
+/// Correlates one source with the single newly-created Trash entry carrying
+/// the same stable filesystem identity. Names are treated as opaque; Finder's
+/// collision naming scheme is never parsed or guessed.
+#[cfg(any(test, target_os = "macos"))]
+fn correlate_trash_name(
+    before: &TrashSnapshot,
+    after: &TrashSnapshot,
+    source: TrashEntryIdentity,
+) -> Result<OsString, TrashNameCorrelationError> {
+    let mut matches = after
+        .iter()
+        .filter(|(name, identity)| !before.contains_key(*name) && **identity == source)
+        .map(|(name, _)| name.clone());
+    let Some(name) = matches.next() else {
+        return Err(TrashNameCorrelationError::Missing);
+    };
+    let additional = matches.count();
+    if additional == 0 {
+        Ok(name)
+    } else {
+        Err(TrashNameCorrelationError::Ambiguous(additional + 1))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn trash_with_macos_finder(paths: &[&Path]) -> TrashBatchBackendResult {
+    let trash_dir = crate::config::trash_home_dir().map(|home| home.join(".Trash"));
+    let before = trash_dir
+        .as_deref()
+        .ok_or_else(|| "could not determine the selected user's Trash directory".to_string())
+        .and_then(macos_trash_snapshot);
+    let source_identities = paths
+        .iter()
+        .map(|path| {
+            macos_file_identity(path)
+                .map_err(|error| format!("could not identify {:?} before Trash: {error}", path))
+        })
+        .collect::<Vec<_>>();
+
+    if let Err(error) = trash_with_crate(paths) {
+        return TrashBatchBackendResult::Failed {
+            completed: 0,
+            error,
+        };
+    }
+
+    let completed = paths.len();
+    let mut warnings = Vec::new();
+    let mut origins = Vec::new();
+
+    match (trash_dir.as_deref(), before) {
+        (_, Err(error)) => warnings.push(error),
+        (Some(trash_dir), Ok(before)) => match macos_trash_snapshot(trash_dir) {
+            Err(error) => warnings.push(error),
+            Ok(after) => {
+                for (path, identity) in paths.iter().zip(source_identities) {
+                    let identity = match identity {
+                        Ok(identity) => identity,
+                        Err(error) => {
+                            warnings.push(error);
+                            continue;
+                        }
+                    };
+                    let actual_name = match correlate_trash_name(&before, &after, identity) {
+                        Ok(name) => name,
+                        Err(TrashNameCorrelationError::Missing) => {
+                            warnings.push(format!("for {:?}: no matching new Trash entry", path));
+                            continue;
+                        }
+                        Err(TrashNameCorrelationError::Ambiguous(count)) => {
+                            warnings.push(format!(
+                                "for {:?}: {count} matching new Trash entries",
+                                path
+                            ));
+                            continue;
+                        }
+                    };
+                    let Ok(actual_name) = actual_name.into_string() else {
+                        warnings.push(format!("for {:?}: Trash name is not valid UTF-8", path));
+                        continue;
+                    };
+                    origins.push((actual_name, (*path).to_path_buf()));
+                }
+            }
+        },
+        (None, Ok(_)) => unreachable!("a snapshot requires a Trash directory"),
+    }
+
+    if !origins.is_empty() {
+        match crate::fs::save_restore_origins_checked(&origins) {
+            Ok(rejected) => {
+                for path in rejected {
+                    warnings.push(format!("for {path:?}: original path is not valid UTF-8"));
+                }
+            }
+            Err(error) => warnings.push(format!("could not save Trash origins: {error}")),
+        }
+    }
+
+    finish_macos_trash(completed, warnings)
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn finish_macos_trash(completed: usize, warnings: Vec<String>) -> TrashBatchBackendResult {
+    if warnings.is_empty() {
+        TrashBatchBackendResult::Completed
+    } else {
+        TrashBatchBackendResult::CompletedWithWarning {
+            completed,
+            warning: warnings.join("; "),
+        }
+    }
+}
+
+#[cfg(any(target_os = "macos", all(test, unix)))]
+fn macos_file_identity(path: &Path) -> Result<TrashEntryIdentity, String> {
+    use std::os::unix::fs::MetadataExt;
+
+    fs::symlink_metadata(path)
+        .map(|metadata| TrashEntryIdentity {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        })
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(any(target_os = "macos", all(test, unix)))]
+fn macos_trash_snapshot(trash_dir: &Path) -> Result<TrashSnapshot, String> {
+    let entries = match fs::read_dir(trash_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(TrashSnapshot::new());
+        }
+        Err(error) => return Err(format!("could not read {:?}: {error}", trash_dir)),
+    };
+    let mut snapshot = TrashSnapshot::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("could not read {:?}: {error}", trash_dir))?;
+        let identity = macos_file_identity(&entry.path())
+            .map_err(|error| format!("could not identify {:?}: {error}", entry.path()))?;
+        snapshot.insert(entry.file_name(), identity);
+    }
+    Ok(snapshot)
 }
 
 #[cfg(target_os = "linux")]

--- a/src/app/jobs/tasks/trash.rs
+++ b/src/app/jobs/tasks/trash.rs
@@ -508,6 +508,11 @@ fn run_trash_batch(
     let paths: Vec<_> = request.targets.iter().map(|t| t.path.as_path()).collect();
     let total = paths.len();
 
+    #[cfg(all(unix, not(target_os = "macos")))]
+    if let Some(result) = trash_as_invoking_user(&paths) {
+        return result;
+    }
+
     match trash_with_system_backend(&paths) {
         TrashBatchBackendResult::Completed => {
             #[cfg(target_os = "macos")]
@@ -529,6 +534,50 @@ fn run_trash_batch(
 enum TrashBatchBackendResult {
     Completed,
     Failed { completed: usize, error: String },
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn trash_as_invoking_user(paths: &[&Path]) -> Option<(usize, Vec<String>, bool)> {
+    use crate::{
+        config::{InvocationContext, invoking_user_context},
+        user_fs_helper::Request,
+    };
+
+    match invoking_user_context() {
+        InvocationContext::Normal => None,
+        InvocationContext::ElevatedUnresolved => Some((
+            0,
+            vec!["Could not resolve invoking user; nothing was trashed".to_string()],
+            false,
+        )),
+        InvocationContext::Elevated(user) => {
+            let owned = paths.iter().map(|path| (*path).to_path_buf()).collect();
+            let response = super::super::invoking_user_fs::run(&user, &Request::Trash(owned));
+            Some(match response {
+                Ok(response) => (
+                    response.completed,
+                    response.error.into_iter().collect(),
+                    false,
+                ),
+                Err(error) => (0, vec![format!("Could not trash items: {error}")], false),
+            })
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn run_user_trash_helper(paths: &[PathBuf]) -> crate::user_fs_helper::Response {
+    let refs: Vec<_> = paths.iter().map(PathBuf::as_path).collect();
+    match trash_with_system_backend(&refs) {
+        TrashBatchBackendResult::Completed => crate::user_fs_helper::Response {
+            completed: paths.len(),
+            error: None,
+        },
+        TrashBatchBackendResult::Failed { completed, error } => crate::user_fs_helper::Response {
+            completed,
+            error: Some(error),
+        },
+    }
 }
 
 fn trash_with_system_backend(paths: &[&Path]) -> TrashBatchBackendResult {

--- a/src/app/jobs/tasks/trash/tests.rs
+++ b/src/app/jobs/tasks/trash/tests.rs
@@ -52,6 +52,110 @@ fn restore_origin_cleanup_collects_only_names_inside_selected_trash() {
     assert_eq!(names, vec!["inside.txt".to_string()]);
 }
 
+fn trash_identity(device: u64, inode: u64) -> TrashEntryIdentity {
+    TrashEntryIdentity { device, inode }
+}
+
+#[test]
+fn trash_name_correlation_preserves_finder_assigned_collision_names() {
+    let original = trash_identity(1, 10);
+    let collision = trash_identity(1, 11);
+    let before = TrashSnapshot::from([(OsString::from("unrelated.txt"), trash_identity(1, 99))]);
+    let after = TrashSnapshot::from([
+        (OsString::from("unrelated.txt"), trash_identity(1, 99)),
+        (OsString::from("foo.txt"), original),
+        (OsString::from("foo 11.53.48.txt"), collision),
+    ]);
+
+    assert_eq!(
+        correlate_trash_name(&before, &after, original),
+        Ok(OsString::from("foo.txt"))
+    );
+    assert_eq!(
+        correlate_trash_name(&before, &after, collision),
+        Ok(OsString::from("foo 11.53.48.txt"))
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn trash_snapshot_correlation_tracks_identity_across_renames() {
+    let root = make_tmp_dir("trash-snapshot-collision");
+    let trash_dir = root.join("Trash");
+    let source_a = root.join("A/foo.txt");
+    let source_b = root.join("B/foo.txt");
+    fs::create_dir_all(source_a.parent().unwrap()).unwrap();
+    fs::create_dir_all(source_b.parent().unwrap()).unwrap();
+    fs::create_dir(&trash_dir).unwrap();
+    fs::write(&source_a, b"from A").unwrap();
+    fs::write(&source_b, b"from B").unwrap();
+    let identity_a = macos_file_identity(&source_a).unwrap();
+    let identity_b = macos_file_identity(&source_b).unwrap();
+    let before = macos_trash_snapshot(&trash_dir).unwrap();
+
+    fs::rename(&source_a, trash_dir.join("foo.txt")).unwrap();
+    fs::rename(&source_b, trash_dir.join("foo 11.53.48.txt")).unwrap();
+    let after = macos_trash_snapshot(&trash_dir).unwrap();
+
+    assert_eq!(
+        correlate_trash_name(&before, &after, identity_a),
+        Ok(OsString::from("foo.txt"))
+    );
+    assert_eq!(
+        correlate_trash_name(&before, &after, identity_b),
+        Ok(OsString::from("foo 11.53.48.txt"))
+    );
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn trash_name_correlation_rejects_ambiguous_identity_matches() {
+    let identity = trash_identity(1, 10);
+    let after = TrashSnapshot::from([
+        (OsString::from("foo.txt"), identity),
+        (OsString::from("foo 11.53.48.txt"), identity),
+    ]);
+
+    assert_eq!(
+        correlate_trash_name(&TrashSnapshot::new(), &after, identity),
+        Err(TrashNameCorrelationError::Ambiguous(2))
+    );
+}
+
+#[test]
+fn trash_name_correlation_never_reuses_preexisting_names() {
+    let identity = trash_identity(1, 10);
+    let before = TrashSnapshot::from([(OsString::from("foo.txt"), identity)]);
+    let after = before.clone();
+
+    assert_eq!(
+        correlate_trash_name(&before, &after, identity),
+        Err(TrashNameCorrelationError::Missing)
+    );
+}
+
+#[test]
+fn restore_metadata_warning_preserves_completed_trash_count() {
+    assert_eq!(
+        finish_macos_trash(1, vec!["store is read-only".to_string()]),
+        TrashBatchBackendResult::CompletedWithWarning {
+            completed: 1,
+            warning: "store is read-only".to_string(),
+        }
+    );
+}
+
+#[test]
+fn restore_metadata_warning_is_rendered_as_partial_success() {
+    let status = format_restore_metadata_warning("Trashed", 1, &["store is read-only".to_string()]);
+
+    assert_eq!(
+        status,
+        "Trashed 1 item; restore metadata could not be saved: store is read-only"
+    );
+    assert!(!status.contains("error"));
+}
+
 // ── GIO trash backend ─────────────────────────────────────────────────
 
 #[cfg(target_os = "linux")]

--- a/src/app/jobs/tasks/trash/tests.rs
+++ b/src/app/jobs/tasks/trash/tests.rs
@@ -21,6 +21,21 @@ fn path_refs(paths: &[PathBuf]) -> Vec<&Path> {
     paths.iter().map(|path| path.as_path()).collect()
 }
 
+#[test]
+fn root_permanent_delete_does_not_stage_in_user_data_dir() {
+    let data_dir = PathBuf::from("/home/paco/.local/share");
+    assert_eq!(staging_root_for(Some(data_dir), 0), None);
+}
+
+#[test]
+fn normal_permanent_delete_keeps_existing_staging_root() {
+    let data_dir = PathBuf::from("/home/paco/.local/share");
+    assert_eq!(
+        staging_root_for(Some(data_dir.clone()), 1000),
+        Some(data_dir.join("elio/cleanup"))
+    );
+}
+
 // ── GIO trash backend ─────────────────────────────────────────────────
 
 #[cfg(target_os = "linux")]

--- a/src/app/jobs/tasks/trash/tests.rs
+++ b/src/app/jobs/tasks/trash/tests.rs
@@ -36,6 +36,22 @@ fn normal_permanent_delete_keeps_existing_staging_root() {
     );
 }
 
+#[test]
+fn restore_origin_cleanup_collects_only_names_inside_selected_trash() {
+    let trash_dir = Path::new("/Users/paco/.Trash");
+    let inside = trash_dir.join("inside.txt");
+    let outside = PathBuf::from("/Users/paco/Documents/outside.txt");
+    let nested = trash_dir.join("folder/nested.txt");
+    let mut names = Vec::new();
+
+    collect_deleted_restore_origin(&inside, Some(trash_dir), &mut names);
+    collect_deleted_restore_origin(&outside, Some(trash_dir), &mut names);
+    collect_deleted_restore_origin(&nested, Some(trash_dir), &mut names);
+    collect_deleted_restore_origin(&inside, None, &mut names);
+
+    assert_eq!(names, vec!["inside.txt".to_string()]);
+}
+
 // ── GIO trash backend ─────────────────────────────────────────────────
 
 #[cfg(target_os = "linux")]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -36,6 +36,9 @@ use std::{
 };
 
 pub use self::state::App;
+
+#[cfg(unix)]
+pub(crate) use self::jobs::run_user_trash_helper;
 #[cfg(test)]
 pub use self::state::PreviewMetricsSnapshot;
 pub(crate) use self::state::{ChooserExit, DuplicateRow, PendingTerminalTask};

--- a/src/app/open_rules.rs
+++ b/src/app/open_rules.rs
@@ -1,4 +1,4 @@
-use std::{env, ffi::OsString, path::PathBuf};
+use std::{ffi::OsString, path::PathBuf};
 
 use crate::{
     config::{self, OpenPlatform, OpenRule, OpenTargetType},
@@ -121,7 +121,7 @@ fn entry_is_text_like(entry: &Entry, facts: file_info::FileFacts) -> bool {
 }
 
 fn command_template(command: &str) -> Result<CommandTemplate, String> {
-    command_template_with_env(command, env::var_os)
+    command_template_with_env(command, config::invoking_user_env_var)
 }
 
 fn command_template_with_env(

--- a/src/app/open_with/discovery/editor.rs
+++ b/src/app/open_with/discovery/editor.rs
@@ -1,7 +1,10 @@
 use std::{
-    env, fs,
+    fs,
     path::{Path, PathBuf},
 };
+
+#[cfg(test)]
+use std::env;
 
 use super::super::super::state::OpenWithApp;
 use super::exec::tokenize_exec;
@@ -39,7 +42,8 @@ pub(super) fn editor_fallback_for_path(path: &Path) -> Option<OpenWithApp> {
 }
 
 pub(super) fn editor_app_for_path(var: &'static str, path: &Path) -> Option<OpenWithApp> {
-    let value = env::var_os(var).and_then(|value| value.into_string().ok())?;
+    let value =
+        crate::config::invoking_user_env_var(var).and_then(|value| value.into_string().ok())?;
     editor_app_from_command(var, &value, path)
 }
 
@@ -134,8 +138,8 @@ pub(super) fn resolve_executable(program: &str) -> Option<PathBuf> {
         return executable_file_exists(program_path).then(|| canonical_path(program_path));
     }
 
-    env::var_os("PATH").and_then(|paths| {
-        env::split_paths(&paths)
+    crate::config::invoking_user_env_var("PATH").and_then(|paths| {
+        std::env::split_paths(&paths)
             .map(|dir| dir.join(program))
             .find(|path| executable_file_exists(path))
             .map(|path| canonical_path(&path))

--- a/src/app/open_with/discovery/gio.rs
+++ b/src/app/open_with/discovery/gio.rs
@@ -23,6 +23,7 @@ pub(super) fn discover_via_gio(
 ) -> Option<Vec<OpenWithApp>> {
     let mut cmd = Command::new("gio");
     cmd.args(["mime", mime]);
+    crate::invoking_user_command::prepare_external(&mut cmd, None).ok()?;
     let output = run_command_capture_stdout_cancellable(cmd, "open-with-gio", canceled)?;
     let text = String::from_utf8_lossy(&output);
 

--- a/src/app/open_with/discovery/mod.rs
+++ b/src/app/open_with/discovery/mod.rs
@@ -73,20 +73,19 @@ fn discover_open_with_apps_inner(
 #[cfg(all(unix, not(target_os = "macos")))]
 pub(super) fn xdg_data_dirs() -> Vec<std::path::PathBuf> {
     let mut dirs = Vec::new();
+    let context = crate::config::invoking_user_context();
 
-    let data_home = std::env::var("XDG_DATA_HOME")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::home_dir()
-                .map(|h| h.join(".local/share"))
-                .unwrap_or_default()
-        });
-    if !data_home.as_os_str().is_empty() {
+    if let Some(data_home) = xdg_data_home_for_context(
+        &context,
+        crate::config::invoking_user_env_var("XDG_DATA_HOME"),
+    ) && !data_home.as_os_str().is_empty()
+    {
         dirs.push(data_home);
     }
 
-    for entry in std::env::var("XDG_DATA_DIRS")
-        .unwrap_or_else(|_| "/usr/local/share:/usr/share".to_string())
+    for entry in crate::config::invoking_user_env_var("XDG_DATA_DIRS")
+        .and_then(|value| value.into_string().ok())
+        .unwrap_or_else(|| "/usr/local/share:/usr/share".to_string())
         .split(':')
         .filter(|s| !s.is_empty())
     {
@@ -96,11 +95,70 @@ pub(super) fn xdg_data_dirs() -> Vec<std::path::PathBuf> {
     dirs
 }
 
+#[cfg(all(unix, not(target_os = "macos")))]
+fn xdg_data_home_for_context(
+    context: &crate::config::InvocationContext,
+    normal_xdg_data_home: Option<std::ffi::OsString>,
+) -> Option<std::path::PathBuf> {
+    match context {
+        crate::config::InvocationContext::Normal => normal_xdg_data_home
+            .map(std::path::PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|home| home.join(".local/share"))),
+        crate::config::InvocationContext::Elevated(user) => user
+            .xdg_data_home
+            .clone()
+            .or_else(|| Some(user.home.join(".local/share"))),
+        crate::config::InvocationContext::ElevatedUnresolved => None,
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(super) fn invoking_home_dir() -> Option<std::path::PathBuf> {
+    invoking_home_dir_for_context(&crate::config::invoking_user_context())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn invoking_home_dir_for_context(
+    context: &crate::config::InvocationContext,
+) -> Option<std::path::PathBuf> {
+    match context {
+        crate::config::InvocationContext::Normal => dirs::home_dir(),
+        crate::config::InvocationContext::Elevated(user) => Some(user.home.clone()),
+        crate::config::InvocationContext::ElevatedUnresolved => None,
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(super) fn invoking_config_home() -> Option<std::path::PathBuf> {
+    invoking_config_home_for_context(
+        &crate::config::invoking_user_context(),
+        crate::config::invoking_user_env_var("XDG_CONFIG_HOME"),
+    )
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn invoking_config_home_for_context(
+    context: &crate::config::InvocationContext,
+    normal_xdg_config_home: Option<std::ffi::OsString>,
+) -> Option<std::path::PathBuf> {
+    match context {
+        crate::config::InvocationContext::Normal => normal_xdg_config_home
+            .map(std::path::PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|home| home.join(".config"))),
+        crate::config::InvocationContext::Elevated(user) => user
+            .xdg_config_home
+            .clone()
+            .or_else(|| Some(user.home.join(".config"))),
+        crate::config::InvocationContext::ElevatedUnresolved => None,
+    }
+}
+
 /// Returns the desktop names from `$XDG_CURRENT_DESKTOP` (colon-separated,
 /// original case).  Empty when the variable is unset or empty.
 #[cfg(all(unix, not(target_os = "macos")))]
 pub(super) fn current_desktops() -> Vec<String> {
-    std::env::var("XDG_CURRENT_DESKTOP")
+    crate::config::invoking_user_env_var("XDG_CURRENT_DESKTOP")
+        .and_then(|value| value.into_string().ok())
         .unwrap_or_default()
         .split(':')
         .filter(|s| !s.is_empty())
@@ -156,4 +214,58 @@ fn discover_xdg_for_mime(
         editor::append_editor_fallback(&mut apps, path, require_text_like_editor);
     }
     apps
+}
+
+#[cfg(all(test, unix, not(target_os = "macos")))]
+mod tests {
+    use std::{ffi::OsString, path::PathBuf};
+
+    use super::*;
+
+    fn test_user() -> crate::config::InvokingUser {
+        crate::config::InvokingUser {
+            uid: 1000,
+            gid: 1000,
+            name: OsString::from("paco"),
+            home: PathBuf::from("/home/paco"),
+            shell: OsString::from("/bin/sh"),
+            groups: vec![1000],
+            session_environment: Vec::new(),
+            xdg_config_home: Some(PathBuf::from("/home/paco/config")),
+            xdg_data_home: Some(PathBuf::from("/home/paco/data")),
+        }
+    }
+
+    #[test]
+    fn elevated_discovery_uses_invoking_user_directories() {
+        let context = crate::config::InvocationContext::Elevated(test_user());
+
+        assert_eq!(
+            invoking_home_dir_for_context(&context),
+            Some(PathBuf::from("/home/paco"))
+        );
+        assert_eq!(
+            xdg_data_home_for_context(&context, Some(OsString::from("/root/data"))),
+            Some(PathBuf::from("/home/paco/data"))
+        );
+        assert_eq!(
+            invoking_config_home_for_context(&context, Some(OsString::from("/root/config")),),
+            Some(PathBuf::from("/home/paco/config"))
+        );
+    }
+
+    #[test]
+    fn unresolved_elevated_discovery_omits_user_directories() {
+        let context = crate::config::InvocationContext::ElevatedUnresolved;
+
+        assert_eq!(invoking_home_dir_for_context(&context), None);
+        assert_eq!(
+            xdg_data_home_for_context(&context, Some(OsString::from("/root/data"))),
+            None
+        );
+        assert_eq!(
+            invoking_config_home_for_context(&context, Some(OsString::from("/root/config")),),
+            None
+        );
+    }
 }

--- a/src/app/open_with/discovery/mod.rs
+++ b/src/app/open_with/discovery/mod.rs
@@ -101,7 +101,8 @@ fn xdg_data_home_for_context(
     normal_xdg_data_home: Option<std::ffi::OsString>,
 ) -> Option<std::path::PathBuf> {
     match context {
-        crate::config::InvocationContext::Normal => normal_xdg_data_home
+        crate::config::InvocationContext::Normal
+        | crate::config::InvocationContext::RootSession => normal_xdg_data_home
             .map(std::path::PathBuf::from)
             .or_else(|| dirs::home_dir().map(|home| home.join(".local/share"))),
         crate::config::InvocationContext::Elevated(user) => user
@@ -122,7 +123,8 @@ fn invoking_home_dir_for_context(
     context: &crate::config::InvocationContext,
 ) -> Option<std::path::PathBuf> {
     match context {
-        crate::config::InvocationContext::Normal => dirs::home_dir(),
+        crate::config::InvocationContext::Normal
+        | crate::config::InvocationContext::RootSession => dirs::home_dir(),
         crate::config::InvocationContext::Elevated(user) => Some(user.home.clone()),
         crate::config::InvocationContext::ElevatedUnresolved => None,
     }
@@ -142,7 +144,8 @@ fn invoking_config_home_for_context(
     normal_xdg_config_home: Option<std::ffi::OsString>,
 ) -> Option<std::path::PathBuf> {
     match context {
-        crate::config::InvocationContext::Normal => normal_xdg_config_home
+        crate::config::InvocationContext::Normal
+        | crate::config::InvocationContext::RootSession => normal_xdg_config_home
             .map(std::path::PathBuf::from)
             .or_else(|| dirs::home_dir().map(|home| home.join(".config"))),
         crate::config::InvocationContext::Elevated(user) => user

--- a/src/app/open_with/discovery/mod.rs
+++ b/src/app/open_with/discovery/mod.rs
@@ -76,7 +76,7 @@ pub(super) fn xdg_data_dirs() -> Vec<std::path::PathBuf> {
     let context = crate::config::invoking_user_context();
 
     if let Some(data_home) = xdg_data_home_for_context(
-        &context,
+        context,
         crate::config::invoking_user_env_var("XDG_DATA_HOME"),
     ) && !data_home.as_os_str().is_empty()
     {
@@ -115,7 +115,7 @@ fn xdg_data_home_for_context(
 
 #[cfg(all(unix, not(target_os = "macos")))]
 pub(super) fn invoking_home_dir() -> Option<std::path::PathBuf> {
-    invoking_home_dir_for_context(&crate::config::invoking_user_context())
+    invoking_home_dir_for_context(crate::config::invoking_user_context())
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -133,7 +133,7 @@ fn invoking_home_dir_for_context(
 #[cfg(all(unix, not(target_os = "macos")))]
 pub(super) fn invoking_config_home() -> Option<std::path::PathBuf> {
     invoking_config_home_for_context(
-        &crate::config::invoking_user_context(),
+        crate::config::invoking_user_context(),
         crate::config::invoking_user_env_var("XDG_CONFIG_HOME"),
     )
 }

--- a/src/app/open_with/discovery/scan.rs
+++ b/src/app/open_with/discovery/scan.rs
@@ -146,7 +146,7 @@ pub(super) fn desktop_entry_dirs() -> Vec<PathBuf> {
     // Flatpak user exports sit between user data home and system dirs.
     // On many systems Flatpak adds this to XDG_DATA_DIRS itself, so the
     // deduplication step below will handle the overlap.
-    if let Some(home) = dirs::home_dir() {
+    if let Some(home) = super::invoking_home_dir() {
         dirs.push(home.join(".local/share/flatpak/exports/share/applications"));
     }
 
@@ -191,14 +191,9 @@ pub(super) fn mimeapps_paths() -> Vec<PathBuf> {
     // ── Config-dir section ────────────────────────────────────────────────────
 
     // $XDG_CONFIG_HOME defaults to ~/.config
-    let config_home = std::env::var("XDG_CONFIG_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::home_dir()
-                .map(|h| h.join(".config"))
-                .unwrap_or_default()
-        });
-    if !config_home.as_os_str().is_empty() {
+    if let Some(config_home) = super::invoking_config_home()
+        && !config_home.as_os_str().is_empty()
+    {
         for desktop in &desktops {
             paths.push(config_home.join(format!("{desktop}-mimeapps.list")));
         }
@@ -206,8 +201,9 @@ pub(super) fn mimeapps_paths() -> Vec<PathBuf> {
     }
 
     // $XDG_CONFIG_DIRS defaults to /etc/xdg
-    for dir in std::env::var("XDG_CONFIG_DIRS")
-        .unwrap_or_else(|_| "/etc/xdg".to_string())
+    for dir in crate::config::invoking_user_env_var("XDG_CONFIG_DIRS")
+        .and_then(|value| value.into_string().ok())
+        .unwrap_or_else(|| "/etc/xdg".to_string())
         .split(':')
         .filter(|s| !s.is_empty())
         .map(PathBuf::from)

--- a/src/app/open_with/overlay.rs
+++ b/src/app/open_with/overlay.rs
@@ -111,7 +111,9 @@ impl App {
         } else {
             match detached_open_command(&program, &args) {
                 Ok(()) => self.status.clear(),
-                Err(_) => self.status = format!("Failed to open with {display_name}"),
+                Err(error) => {
+                    self.status = format!("Failed to open with {display_name}: {error}");
+                }
             }
         }
 
@@ -158,7 +160,10 @@ impl App {
                 } else {
                     match launch_app(&app) {
                         Ok(()) => self.status = format!("Opened with {}", app.display_name),
-                        Err(_) => self.status = format!("Failed to open with {}", app.display_name),
+                        Err(error) => {
+                            self.status =
+                                format!("Failed to open with {}: {error}", app.display_name);
+                        }
                     }
                 }
             }
@@ -261,21 +266,7 @@ fn open_with_fallback(path: &Path) -> std::result::Result<FallbackOpenOutcome, S
 
 #[cfg(target_os = "macos")]
 fn open_in_text_editor(path: &Path) -> std::result::Result<(), String> {
-    use std::process::{Command, Stdio};
-
-    let status = Command::new("open")
-        .arg("-t")
-        .arg(path)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map_err(|e| format!("open: {e}"))?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(format!("open exited with {status}"))
-    }
+    crate::fs::detached_open("open", &["-t"], path).map_err(|error| format!("open: {error}"))
 }
 
 // ── Test seam ─────────────────────────────────────────────────────────────────

--- a/src/app/open_with/tests.rs
+++ b/src/app/open_with/tests.rs
@@ -123,7 +123,7 @@ fn single_discovered_app_launch_failure_sets_status_without_overlay() {
         app.overlays.open_with.is_none(),
         "overlay must remain closed"
     );
-    assert_eq!(app.status, "Failed to open with Ghost App");
+    assert_eq!(app.status, "Failed to open with Ghost App: missing");
 
     fs::remove_dir_all(root).ok();
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -227,6 +227,7 @@ pub(super) struct BulkRenameItem {
 pub(crate) struct BulkRenameEditorSession {
     pub(crate) root: PathBuf,
     pub(crate) temp_path: PathBuf,
+    pub(crate) expected_temp_owner: Option<libc::uid_t>,
     pub(super) items: Vec<BulkRenameItem>,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,7 @@ pub(crate) fn run() -> Result<ExitCode> {
             print_help();
             Ok(ExitCode::SUCCESS)
         }
+        Command::UserFsHelper => elio::run_user_fs_helper().map(|()| ExitCode::SUCCESS),
         Command::PrintShellInit(shell) => {
             let executable = env::current_exe()?;
             let invocation = env::args().next();
@@ -113,6 +114,7 @@ enum Command {
     PrintShellInit(Shell),
     InstallShellIntegration(Option<Shell>),
     UninstallShellIntegration(Option<Shell>),
+    UserFsHelper,
 }
 
 fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Command> {
@@ -128,6 +130,7 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Command> {
     }
 
     match args.as_slice() {
+        [arg] if arg == "--internal-user-fs-helper" => return Ok(Command::UserFsHelper),
         [arg] if arg == "--version" || arg == "-V" => return Ok(Command::PrintVersion),
         [arg] if arg == "--help" || arg == "-h" => return Ok(Command::PrintHelp),
         [arg, unexpected, ..] if arg == "--version" || arg == "-V" => {

--- a/src/config/invoking_user.rs
+++ b/src/config/invoking_user.rs
@@ -57,16 +57,25 @@ pub(crate) struct InvokingUser {
 #[derive(Clone, Debug)]
 pub(crate) enum InvocationContext {
     Normal,
+    RootSession,
     Elevated(InvokingUser),
     ElevatedUnresolved,
 }
 
 #[cfg(unix)]
 pub(crate) fn context() -> InvocationContext {
+    let sudo_uid = env::var_os("SUDO_UID");
+    let doas_user = env::var_os("DOAS_USER");
+    let has_elevation_metadata = sudo_uid.is_some()
+        || doas_user.is_some()
+        || ["SUDO_COMMAND", "SUDO_GID", "SUDO_USER"]
+            .into_iter()
+            .any(|name| env::var_os(name).is_some());
     invocation_context(
         unsafe { libc::geteuid() },
-        env::var_os("SUDO_UID").as_deref(),
-        env::var_os("DOAS_USER").as_deref(),
+        sudo_uid.as_deref(),
+        doas_user.as_deref(),
+        has_elevation_metadata,
     )
 }
 
@@ -82,7 +91,7 @@ fn env_var_for_context(
     normal_value: Option<OsString>,
 ) -> Option<OsString> {
     match context {
-        InvocationContext::Normal => normal_value,
+        InvocationContext::Normal | InvocationContext::RootSession => normal_value,
         InvocationContext::Elevated(user) => user
             .session_environment
             .into_iter()
@@ -100,7 +109,9 @@ pub(crate) fn env_var(name: &str) -> Option<std::ffi::OsString> {
 pub(crate) fn home_dir() -> Option<PathBuf> {
     match context() {
         InvocationContext::Elevated(user) => Some(user.home),
-        InvocationContext::Normal | InvocationContext::ElevatedUnresolved => dirs::home_dir(),
+        InvocationContext::Normal
+        | InvocationContext::RootSession
+        | InvocationContext::ElevatedUnresolved => dirs::home_dir(),
     }
 }
 
@@ -119,7 +130,7 @@ pub(crate) fn trash_home_dir() -> Option<std::path::PathBuf> {
 #[cfg(all(unix, not(target_os = "macos")))]
 fn trash_home_for_context(context: InvocationContext) -> Option<PathBuf> {
     match context {
-        InvocationContext::Normal => dirs::home_dir(),
+        InvocationContext::Normal | InvocationContext::RootSession => dirs::home_dir(),
         InvocationContext::Elevated(user) => Some(user.home),
         InvocationContext::ElevatedUnresolved => None,
     }
@@ -128,7 +139,7 @@ fn trash_home_for_context(context: InvocationContext) -> Option<PathBuf> {
 #[cfg(all(unix, not(target_os = "macos")))]
 pub(crate) fn trash_data_dir() -> Option<PathBuf> {
     match context() {
-        InvocationContext::Normal => dirs::data_dir(),
+        InvocationContext::Normal | InvocationContext::RootSession => dirs::data_dir(),
         InvocationContext::Elevated(user) => user
             .xdg_data_home
             .or_else(|| Some(user.home.join(".local/share"))),
@@ -141,9 +152,13 @@ fn invocation_context(
     effective_uid: libc::uid_t,
     sudo_uid: Option<&OsStr>,
     doas_user: Option<&OsStr>,
+    has_elevation_metadata: bool,
 ) -> InvocationContext {
     if effective_uid != 0 {
         return InvocationContext::Normal;
+    }
+    if !has_elevation_metadata {
+        return InvocationContext::RootSession;
     }
     let user = parse_non_root_uid(sudo_uid)
         .and_then(passwd_by_uid)
@@ -531,8 +546,21 @@ mod tests {
     #[test]
     fn non_root_process_ignores_elevation_metadata() {
         assert!(matches!(
-            invocation_context(1000, Some(OsStr::new("1001")), Some(OsStr::new("paco"))),
+            invocation_context(
+                1000,
+                Some(OsStr::new("1001")),
+                Some(OsStr::new("paco")),
+                true,
+            ),
             InvocationContext::Normal
+        ));
+    }
+
+    #[test]
+    fn root_without_elevation_metadata_is_root_session() {
+        assert!(matches!(
+            invocation_context(0, None, None, false),
+            InvocationContext::RootSession
         ));
     }
 
@@ -544,7 +572,7 @@ mod tests {
         }
         let expected = passwd_by_uid(uid).expect("current user should have a passwd record");
         let InvocationContext::Elevated(actual) =
-            invocation_context(0, Some(OsStr::new(&uid.to_string())), None)
+            invocation_context(0, Some(OsStr::new(&uid.to_string())), None, true)
         else {
             panic!("current user should resolve as invoking user");
         };
@@ -558,7 +586,12 @@ mod tests {
     #[test]
     fn unresolved_elevated_context_does_not_become_normal() {
         assert!(matches!(
-            invocation_context(0, Some(OsStr::new("invalid")), Some(OsStr::new("root"))),
+            invocation_context(
+                0,
+                Some(OsStr::new("invalid")),
+                Some(OsStr::new("root")),
+                true,
+            ),
             InvocationContext::ElevatedUnresolved
         ));
     }

--- a/src/config/invoking_user.rs
+++ b/src/config/invoking_user.rs
@@ -6,6 +6,7 @@ use std::{
     os::unix::ffi::{OsStrExt, OsStringExt},
     path::PathBuf,
     ptr,
+    sync::OnceLock,
 };
 
 #[cfg(target_os = "linux")]
@@ -40,7 +41,7 @@ pub(crate) const SESSION_ENVIRONMENT_KEYS: &[&str] = &[
 ];
 
 #[cfg(unix)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct InvokingUser {
     pub(crate) uid: libc::uid_t,
     pub(crate) gid: libc::gid_t,
@@ -54,7 +55,7 @@ pub(crate) struct InvokingUser {
 }
 
 #[cfg(unix)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) enum InvocationContext {
     Normal,
     RootSession,
@@ -63,7 +64,15 @@ pub(crate) enum InvocationContext {
 }
 
 #[cfg(unix)]
-pub(crate) fn context() -> InvocationContext {
+static INVOCATION_CONTEXT: OnceLock<InvocationContext> = OnceLock::new();
+
+#[cfg(unix)]
+pub(crate) fn context() -> &'static InvocationContext {
+    INVOCATION_CONTEXT.get_or_init(detect_context)
+}
+
+#[cfg(unix)]
+fn detect_context() -> InvocationContext {
     let sudo_uid = env::var_os("SUDO_UID");
     let doas_user = env::var_os("DOAS_USER");
     let has_elevation_metadata = sudo_uid.is_some()
@@ -86,16 +95,15 @@ pub(crate) fn env_var(name: &str) -> Option<OsString> {
 
 #[cfg(unix)]
 fn env_var_for_context(
-    context: InvocationContext,
+    context: &InvocationContext,
     name: &str,
     normal_value: Option<OsString>,
 ) -> Option<OsString> {
     match context {
         InvocationContext::Normal | InvocationContext::RootSession => normal_value,
-        InvocationContext::Elevated(user) => user
-            .session_environment
-            .into_iter()
-            .find_map(|(key, value)| (key == name).then_some(value)),
+        InvocationContext::Elevated(user) => {
+            user_environment_value(user, name).map(OsStr::to_os_string)
+        }
         InvocationContext::ElevatedUnresolved => None,
     }
 }
@@ -108,7 +116,7 @@ pub(crate) fn env_var(name: &str) -> Option<std::ffi::OsString> {
 #[cfg(unix)]
 pub(crate) fn home_dir() -> Option<PathBuf> {
     match context() {
-        InvocationContext::Elevated(user) => Some(user.home),
+        InvocationContext::Elevated(user) => Some(user.home.clone()),
         InvocationContext::Normal
         | InvocationContext::RootSession
         | InvocationContext::ElevatedUnresolved => dirs::home_dir(),
@@ -128,10 +136,10 @@ pub(crate) fn trash_home_dir() -> Option<std::path::PathBuf> {
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
-fn trash_home_for_context(context: InvocationContext) -> Option<PathBuf> {
+fn trash_home_for_context(context: &InvocationContext) -> Option<PathBuf> {
     match context {
         InvocationContext::Normal | InvocationContext::RootSession => dirs::home_dir(),
-        InvocationContext::Elevated(user) => Some(user.home),
+        InvocationContext::Elevated(user) => Some(user.home.clone()),
         InvocationContext::ElevatedUnresolved => None,
     }
 }
@@ -142,6 +150,7 @@ pub(crate) fn trash_data_dir() -> Option<PathBuf> {
         InvocationContext::Normal | InvocationContext::RootSession => dirs::data_dir(),
         InvocationContext::Elevated(user) => user
             .xdg_data_home
+            .clone()
             .or_else(|| Some(user.home.join(".local/share"))),
         InvocationContext::ElevatedUnresolved => None,
     }
@@ -600,7 +609,7 @@ mod tests {
     fn elevated_environment_uses_invoking_user_value_not_root_value() {
         assert_eq!(
             env_var_for_context(
-                InvocationContext::Elevated(test_user()),
+                &InvocationContext::Elevated(test_user()),
                 "EDITOR",
                 Some(OsString::from("root-editor")),
             ),
@@ -608,7 +617,7 @@ mod tests {
         );
         assert_eq!(
             env_var_for_context(
-                InvocationContext::Elevated(test_user()),
+                &InvocationContext::Elevated(test_user()),
                 "DISPLAY",
                 Some(OsString::from(":root")),
             ),
@@ -620,7 +629,7 @@ mod tests {
     fn normal_environment_remains_unchanged() {
         assert_eq!(
             env_var_for_context(
-                InvocationContext::Normal,
+                &InvocationContext::Normal,
                 "EDITOR",
                 Some(OsString::from("nvim")),
             ),
@@ -717,8 +726,13 @@ mod tests {
     #[test]
     fn unresolved_elevated_context_has_no_trash_home() {
         assert_eq!(
-            trash_home_for_context(InvocationContext::ElevatedUnresolved),
+            trash_home_for_context(&InvocationContext::ElevatedUnresolved),
             None
         );
+    }
+
+    #[test]
+    fn process_context_is_resolved_once() {
+        assert!(std::ptr::eq(context(), context()));
     }
 }

--- a/src/config/invoking_user.rs
+++ b/src/config/invoking_user.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 #[cfg(unix)]
-pub(super) fn home_dir() -> Option<PathBuf> {
+pub(crate) fn home_dir() -> Option<PathBuf> {
     elevated_home_dir(
         unsafe { libc::geteuid() },
         env::var_os("SUDO_UID").as_deref(),
@@ -19,7 +19,7 @@ pub(super) fn home_dir() -> Option<PathBuf> {
 }
 
 #[cfg(not(unix))]
-pub(super) fn home_dir() -> Option<std::path::PathBuf> {
+pub(crate) fn home_dir() -> Option<std::path::PathBuf> {
     dirs::home_dir()
 }
 

--- a/src/config/invoking_user.rs
+++ b/src/config/invoking_user.rs
@@ -196,7 +196,11 @@ fn invocation_context(
     user.session_environment = invoking_user_environment(user.uid);
     user.xdg_config_home =
         validated_xdg_home(user_environment_value(&user, "XDG_CONFIG_HOME"), &user);
-    user.xdg_data_home = validated_xdg_home(user_environment_value(&user, "XDG_DATA_HOME"), &user);
+    #[cfg(not(target_os = "macos"))]
+    {
+        user.xdg_data_home =
+            validated_xdg_home(user_environment_value(&user, "XDG_DATA_HOME"), &user);
+    }
     InvocationContext::Elevated(user)
 }
 
@@ -331,7 +335,7 @@ fn passwd(
     }
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 fn validated_xdg_home(value: Option<&OsStr>, user: &InvokingUser) -> Option<PathBuf> {
     use std::os::unix::fs::MetadataExt;
 
@@ -347,11 +351,6 @@ fn validated_xdg_home(value: Option<&OsStr>, user: &InvokingUser) -> Option<Path
                 })
                 == Some(true)
         })
-}
-
-#[cfg(target_os = "macos")]
-fn validated_xdg_home(_value: Option<&OsStr>, _user: &InvokingUser) -> Option<PathBuf> {
-    None
 }
 
 #[cfg(unix)]
@@ -622,6 +621,38 @@ mod tests {
         assert_eq!(parse_uid(Some(OsStr::new("0"))), Some(0));
         assert_eq!(parse_uid(Some(OsStr::new("paco"))), None);
         assert_eq!(parse_uid(None), None);
+    }
+
+    #[test]
+    fn invoking_user_xdg_home_rejects_untrusted_paths() {
+        let user = test_user();
+        assert_eq!(
+            validated_xdg_home(Some(OsStr::new("relative/config")), &user),
+            None
+        );
+        assert_eq!(
+            validated_xdg_home(Some(OsStr::new("/root/custom")), &user),
+            None
+        );
+    }
+
+    #[test]
+    fn invoking_user_xdg_home_accepts_user_owned_absolute_path() {
+        let uid = unsafe { libc::geteuid() };
+        let user = passwd_by_uid(uid).expect("current user should have a passwd record");
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should follow the Unix epoch")
+            .as_nanos();
+        let base =
+            std::env::temp_dir().join(format!("elio-xdg-home-{}-{unique}", std::process::id()));
+        std::fs::create_dir(&base).expect("failed to create user-owned XDG test directory");
+        let candidate = base.join("config");
+
+        let actual = validated_xdg_home(Some(candidate.as_os_str()), &user);
+
+        std::fs::remove_dir(base).expect("failed to remove XDG test directory");
+        assert_eq!(actual, Some(candidate));
     }
 
     #[test]

--- a/src/config/invoking_user.rs
+++ b/src/config/invoking_user.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
 use std::{
     env,
-    ffi::{CStr, CString, OsStr},
+    ffi::{CStr, CString, OsStr, OsString},
     mem,
     os::unix::ffi::{OsStrExt, OsStringExt},
     path::PathBuf,
@@ -9,13 +9,39 @@ use std::{
 };
 
 #[cfg(unix)]
-pub(crate) fn home_dir() -> Option<PathBuf> {
-    elevated_home_dir(
+#[derive(Clone, Debug)]
+pub(crate) struct InvokingUser {
+    pub(crate) uid: libc::uid_t,
+    pub(crate) gid: libc::gid_t,
+    pub(crate) name: OsString,
+    pub(crate) home: PathBuf,
+    pub(crate) groups: Vec<libc::gid_t>,
+    pub(crate) xdg_data_home: Option<PathBuf>,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug)]
+pub(crate) enum InvocationContext {
+    Normal,
+    Elevated(InvokingUser),
+    ElevatedUnresolved,
+}
+
+#[cfg(unix)]
+pub(crate) fn context() -> InvocationContext {
+    invocation_context(
         unsafe { libc::geteuid() },
         env::var_os("SUDO_UID").as_deref(),
         env::var_os("DOAS_USER").as_deref(),
     )
-    .or_else(dirs::home_dir)
+}
+
+#[cfg(unix)]
+pub(crate) fn home_dir() -> Option<PathBuf> {
+    match context() {
+        InvocationContext::Elevated(user) => Some(user.home),
+        InvocationContext::Normal | InvocationContext::ElevatedUnresolved => dirs::home_dir(),
+    }
 }
 
 #[cfg(not(unix))]
@@ -23,18 +49,54 @@ pub(crate) fn home_dir() -> Option<std::path::PathBuf> {
     dirs::home_dir()
 }
 
+pub(crate) fn trash_home_dir() -> Option<std::path::PathBuf> {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    return trash_home_for_context(context());
+    #[cfg(any(not(unix), target_os = "macos"))]
+    return dirs::home_dir();
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn trash_home_for_context(context: InvocationContext) -> Option<PathBuf> {
+    match context {
+        InvocationContext::Normal => dirs::home_dir(),
+        InvocationContext::Elevated(user) => Some(user.home),
+        InvocationContext::ElevatedUnresolved => None,
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(crate) fn trash_data_dir() -> Option<PathBuf> {
+    match context() {
+        InvocationContext::Normal => dirs::data_dir(),
+        InvocationContext::Elevated(user) => user
+            .xdg_data_home
+            .or_else(|| Some(user.home.join(".local/share"))),
+        InvocationContext::ElevatedUnresolved => None,
+    }
+}
+
 #[cfg(unix)]
-fn elevated_home_dir(
+fn invocation_context(
     effective_uid: libc::uid_t,
     sudo_uid: Option<&OsStr>,
     doas_user: Option<&OsStr>,
-) -> Option<PathBuf> {
+) -> InvocationContext {
     if effective_uid != 0 {
-        return None;
+        return InvocationContext::Normal;
     }
-    parse_non_root_uid(sudo_uid)
-        .and_then(passwd_home_by_uid)
-        .or_else(|| doas_user.and_then(passwd_home_by_name))
+    let user = parse_non_root_uid(sudo_uid)
+        .and_then(passwd_by_uid)
+        .or_else(|| doas_user.and_then(passwd_by_name));
+    let Some(mut user) = user else {
+        return InvocationContext::ElevatedUnresolved;
+    };
+    let Some(groups) = supplementary_groups(&user.name, user.gid) else {
+        return InvocationContext::ElevatedUnresolved;
+    };
+    user.groups = groups;
+    user.xdg_data_home = validated_xdg_data_home(&user);
+    InvocationContext::Elevated(user)
 }
 
 #[cfg(unix)]
@@ -44,33 +106,33 @@ fn parse_non_root_uid(value: Option<&OsStr>) -> Option<libc::uid_t> {
 }
 
 #[cfg(unix)]
-fn passwd_home_by_uid(uid: libc::uid_t) -> Option<PathBuf> {
-    passwd_home(|record, buffer, len, result| unsafe {
+fn passwd_by_uid(uid: libc::uid_t) -> Option<InvokingUser> {
+    passwd(|record, buffer, len, result| unsafe {
         libc::getpwuid_r(uid, record, buffer, len, result)
     })
 }
 
 #[cfg(unix)]
-fn passwd_home_by_name(name: &OsStr) -> Option<PathBuf> {
+fn passwd_by_name(name: &OsStr) -> Option<InvokingUser> {
     let bytes = name.as_bytes();
     if bytes.is_empty() || bytes == b"root" {
         return None;
     }
     let name = CString::new(bytes).ok()?;
-    passwd_home(|record, buffer, len, result| unsafe {
+    passwd(|record, buffer, len, result| unsafe {
         libc::getpwnam_r(name.as_ptr(), record, buffer, len, result)
     })
 }
 
 #[cfg(unix)]
-fn passwd_home(
+fn passwd(
     mut lookup: impl FnMut(
         *mut libc::passwd,
         *mut libc::c_char,
         usize,
         *mut *mut libc::passwd,
     ) -> libc::c_int,
-) -> Option<PathBuf> {
+) -> Option<InvokingUser> {
     let mut buffer = vec![0_u8; passwd_buffer_size()];
     loop {
         let mut record = unsafe { mem::zeroed::<libc::passwd>() };
@@ -85,12 +147,125 @@ fn passwd_home(
             buffer.resize(buffer.len() * 2, 0);
             continue;
         }
-        if status != 0 || result.is_null() || record.pw_dir.is_null() {
+        if status != 0
+            || result.is_null()
+            || record.pw_dir.is_null()
+            || record.pw_name.is_null()
+            || record.pw_uid == 0
+        {
             return None;
         }
         let home = unsafe { CStr::from_ptr(record.pw_dir) }.to_bytes();
-        return (!home.is_empty())
-            .then(|| PathBuf::from(std::ffi::OsString::from_vec(home.to_vec())));
+        let name = unsafe { CStr::from_ptr(record.pw_name) }.to_bytes();
+        if home.is_empty() || name.is_empty() {
+            return None;
+        }
+        return Some(InvokingUser {
+            uid: record.pw_uid,
+            gid: record.pw_gid,
+            name: OsString::from_vec(name.to_vec()),
+            home: PathBuf::from(OsString::from_vec(home.to_vec())),
+            groups: vec![record.pw_gid],
+            xdg_data_home: None,
+        });
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn validated_xdg_data_home(user: &InvokingUser) -> Option<PathBuf> {
+    use std::os::unix::fs::MetadataExt;
+
+    env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .filter(|path| {
+            path.ancestors()
+                .find_map(|ancestor| match std::fs::metadata(ancestor) {
+                    Ok(metadata) => Some(metadata.is_dir() && metadata.uid() == user.uid),
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                    Err(_) => Some(false),
+                })
+                == Some(true)
+        })
+}
+
+#[cfg(target_os = "macos")]
+fn validated_xdg_data_home(_user: &InvokingUser) -> Option<PathBuf> {
+    None
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn supplementary_groups(name: &OsStr, primary_gid: libc::gid_t) -> Option<Vec<libc::gid_t>> {
+    let name = CString::new(name.as_bytes()).ok()?;
+    let mut count: libc::c_int = 0;
+    unsafe {
+        libc::getgrouplist(name.as_ptr(), primary_gid, ptr::null_mut(), &mut count);
+    }
+    if count <= 0 {
+        return None;
+    }
+    let mut groups = vec![primary_gid; count as usize];
+    let status =
+        unsafe { libc::getgrouplist(name.as_ptr(), primary_gid, groups.as_mut_ptr(), &mut count) };
+    if status < 0 || count <= 0 {
+        return None;
+    }
+    groups.truncate(count as usize);
+    groups.push(primary_gid);
+    groups.sort_unstable();
+    groups.dedup();
+    Some(groups)
+}
+
+#[cfg(target_os = "macos")]
+fn supplementary_groups(name: &OsStr, primary_gid: libc::gid_t) -> Option<Vec<libc::gid_t>> {
+    const INITIAL_CAPACITY: usize = 16;
+    const MAX_CAPACITY: usize = 16 * 1024;
+
+    let name = CString::new(name.as_bytes()).ok()?;
+    let primary_group = libc::c_int::try_from(primary_gid).ok()?;
+    let mut capacity = INITIAL_CAPACITY;
+
+    loop {
+        let mut native_groups = vec![primary_group; capacity];
+        let mut count = libc::c_int::try_from(native_groups.len()).ok()?;
+        let status = unsafe {
+            libc::getgrouplist(
+                name.as_ptr(),
+                primary_group,
+                native_groups.as_mut_ptr(),
+                &mut count,
+            )
+        };
+
+        if status == 0 {
+            let returned = usize::try_from(count).ok()?;
+            if returned == 0 || returned > native_groups.len() {
+                return None;
+            }
+            let mut groups = native_groups
+                .into_iter()
+                .take(returned)
+                .map(libc::gid_t::try_from)
+                .collect::<Result<Vec<_>, _>>()
+                .ok()?;
+            groups.push(primary_gid);
+            groups.sort_unstable();
+            groups.dedup();
+            return Some(groups);
+        }
+
+        // Darwin does not support a null-buffer sizing probe, and on -1 the
+        // returned count is only the number of entries that fit. Grow from
+        // the previous capacity instead, with a fixed upper bound.
+        if status != -1 || capacity >= MAX_CAPACITY {
+            return None;
+        }
+        let next_capacity = capacity.checked_mul(2)?.min(MAX_CAPACITY);
+        if next_capacity <= capacity {
+            return None;
+        }
+        capacity = next_capacity;
     }
 }
 
@@ -114,10 +289,10 @@ mod tests {
 
     #[test]
     fn non_root_process_ignores_elevation_metadata() {
-        assert_eq!(
-            elevated_home_dir(1000, Some(OsStr::new("1001")), Some(OsStr::new("paco"))),
-            None
-        );
+        assert!(matches!(
+            invocation_context(1000, Some(OsStr::new("1001")), Some(OsStr::new("paco"))),
+            InvocationContext::Normal
+        ));
     }
 
     #[test]
@@ -126,10 +301,32 @@ mod tests {
         if uid == 0 {
             return;
         }
-        let expected = passwd_home_by_uid(uid).expect("current user should have a home directory");
+        let expected = passwd_by_uid(uid).expect("current user should have a passwd record");
+        let InvocationContext::Elevated(actual) =
+            invocation_context(0, Some(OsStr::new(&uid.to_string())), None)
+        else {
+            panic!("current user should resolve as invoking user");
+        };
+        assert_eq!(actual.uid, expected.uid);
+        assert_eq!(actual.gid, expected.gid);
+        assert_eq!(actual.home, expected.home);
+        assert!(actual.groups.contains(&actual.gid));
+    }
+
+    #[test]
+    fn unresolved_elevated_context_does_not_become_normal() {
+        assert!(matches!(
+            invocation_context(0, Some(OsStr::new("invalid")), Some(OsStr::new("root"))),
+            InvocationContext::ElevatedUnresolved
+        ));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn unresolved_elevated_context_has_no_trash_home() {
         assert_eq!(
-            elevated_home_dir(0, Some(OsStr::new(&uid.to_string())), None),
-            Some(expected)
+            trash_home_for_context(InvocationContext::ElevatedUnresolved),
+            None
         );
     }
 }

--- a/src/config/invoking_user.rs
+++ b/src/config/invoking_user.rs
@@ -8,6 +8,30 @@ use std::{
     ptr,
 };
 
+#[cfg(target_os = "linux")]
+use std::io::Read;
+
+#[cfg(unix)]
+pub(crate) const SESSION_ENVIRONMENT_KEYS: &[&str] = &[
+    "DBUS_SESSION_BUS_ADDRESS",
+    "DESKTOP_SESSION",
+    "DISPLAY",
+    "EDITOR",
+    "PATH",
+    "VISUAL",
+    "WAYLAND_DISPLAY",
+    "XAUTHORITY",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_DIRS",
+    "XDG_CONFIG_HOME",
+    "XDG_CURRENT_DESKTOP",
+    "XDG_DATA_DIRS",
+    "XDG_DATA_HOME",
+    "XDG_RUNTIME_DIR",
+    "XDG_SESSION_DESKTOP",
+    "XDG_SESSION_TYPE",
+];
+
 #[cfg(unix)]
 #[derive(Clone, Debug)]
 pub(crate) struct InvokingUser {
@@ -17,6 +41,8 @@ pub(crate) struct InvokingUser {
     pub(crate) home: PathBuf,
     pub(crate) shell: OsString,
     pub(crate) groups: Vec<libc::gid_t>,
+    pub(crate) session_environment: Vec<(OsString, OsString)>,
+    pub(crate) xdg_config_home: Option<PathBuf>,
     pub(crate) xdg_data_home: Option<PathBuf>,
 }
 
@@ -35,6 +61,32 @@ pub(crate) fn context() -> InvocationContext {
         env::var_os("SUDO_UID").as_deref(),
         env::var_os("DOAS_USER").as_deref(),
     )
+}
+
+#[cfg(unix)]
+pub(crate) fn env_var(name: &str) -> Option<OsString> {
+    env_var_for_context(context(), name, env::var_os(name))
+}
+
+#[cfg(unix)]
+fn env_var_for_context(
+    context: InvocationContext,
+    name: &str,
+    normal_value: Option<OsString>,
+) -> Option<OsString> {
+    match context {
+        InvocationContext::Normal => normal_value,
+        InvocationContext::Elevated(user) => user
+            .session_environment
+            .into_iter()
+            .find_map(|(key, value)| (key == name).then_some(value)),
+        InvocationContext::ElevatedUnresolved => None,
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn env_var(name: &str) -> Option<std::ffi::OsString> {
+    std::env::var_os(name)
 }
 
 #[cfg(unix)]
@@ -96,7 +148,10 @@ fn invocation_context(
         return InvocationContext::ElevatedUnresolved;
     };
     user.groups = groups;
-    user.xdg_data_home = validated_xdg_data_home(&user);
+    user.session_environment = invoking_user_environment(user.uid);
+    user.xdg_config_home =
+        validated_xdg_home(user_environment_value(&user, "XDG_CONFIG_HOME"), &user);
+    user.xdg_data_home = validated_xdg_home(user_environment_value(&user, "XDG_DATA_HOME"), &user);
     InvocationContext::Elevated(user)
 }
 
@@ -177,16 +232,18 @@ fn passwd(
                 OsString::from_vec(shell.to_vec())
             },
             groups: vec![record.pw_gid],
+            session_environment: Vec::new(),
+            xdg_config_home: None,
             xdg_data_home: None,
         });
     }
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
-fn validated_xdg_data_home(user: &InvokingUser) -> Option<PathBuf> {
+fn validated_xdg_home(value: Option<&OsStr>, user: &InvokingUser) -> Option<PathBuf> {
     use std::os::unix::fs::MetadataExt;
 
-    env::var_os("XDG_DATA_HOME")
+    value
         .map(PathBuf::from)
         .filter(|path| path.is_absolute())
         .filter(|path| {
@@ -201,8 +258,160 @@ fn validated_xdg_data_home(user: &InvokingUser) -> Option<PathBuf> {
 }
 
 #[cfg(target_os = "macos")]
-fn validated_xdg_data_home(_user: &InvokingUser) -> Option<PathBuf> {
+fn validated_xdg_home(_value: Option<&OsStr>, _user: &InvokingUser) -> Option<PathBuf> {
     None
+}
+
+#[cfg(unix)]
+pub(crate) fn user_environment_value<'a>(user: &'a InvokingUser, name: &str) -> Option<&'a OsStr> {
+    user.session_environment
+        .iter()
+        .find_map(|(key, value)| (key == name).then_some(value.as_os_str()))
+}
+
+#[cfg(unix)]
+fn invoking_user_environment(uid: libc::uid_t) -> Vec<(OsString, OsString)> {
+    #[cfg(target_os = "linux")]
+    {
+        // Do not fall back to root Elio's environment: if the trusted
+        // same-user ancestor cannot be verified, omit session values.
+        linux_ancestor_environment(uid).unwrap_or_default()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = uid;
+        SESSION_ENVIRONMENT_KEYS
+            .iter()
+            .filter_map(|name| env::var_os(name).map(|value| (OsString::from(name), value)))
+            .collect()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_ancestor_environment(uid: libc::uid_t) -> Option<Vec<(OsString, OsString)>> {
+    // sudo/doas may strip desktop-session variables before Elio starts. Walk
+    // only through privileged ancestors to the first process wholly owned by
+    // the already-resolved invoking UID, then recover only the fixed allowlist.
+    let mut pid = unsafe { libc::getppid() };
+    let mut elevation_environment = None;
+    for _ in 0..32 {
+        if pid <= 1 {
+            return None;
+        }
+        let (parent, process_uids) = linux_process_identity(pid)?;
+        if process_uids.iter().all(|process_uid| *process_uid == uid) {
+            let mut environment = linux_process_environment(pid)?;
+            let (_, verified_uids) = linux_process_identity(pid)?;
+            if !verified_uids.iter().all(|process_uid| *process_uid == uid) {
+                return None;
+            }
+            if let Some(elevation_environment) = elevation_environment {
+                environment = merge_linux_environments(environment, elevation_environment);
+            }
+            return Some(environment);
+        }
+        let privileged_bridge = process_uids
+            .iter()
+            .all(|process_uid| *process_uid == 0 || *process_uid == uid)
+            && process_uids.contains(&0);
+        if !privileged_bridge || parent == pid {
+            return None;
+        }
+        if elevation_environment.is_none() {
+            elevation_environment = linux_elevation_environment(pid, process_uids);
+        }
+        pid = parent;
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn linux_elevation_environment(
+    pid: libc::pid_t,
+    expected_uids: [libc::uid_t; 4],
+) -> Option<Vec<(OsString, OsString)>> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let executable = std::fs::read_link(format!("/proc/{pid}/exe")).ok()?;
+    let name = executable.file_name()?.as_bytes();
+    if name != b"sudo" && name != b"doas" {
+        return None;
+    }
+    let metadata = std::fs::metadata(&executable).ok()?;
+    if metadata.uid() != 0 || metadata.permissions().mode() & 0o4000 == 0 {
+        return None;
+    }
+    let environment = linux_process_environment(pid)?;
+    let (_, verified_uids) = linux_process_identity(pid)?;
+    (verified_uids == expected_uids).then_some(environment)
+}
+
+#[cfg(target_os = "linux")]
+fn merge_linux_environments(
+    base: Vec<(OsString, OsString)>,
+    elevation: Vec<(OsString, OsString)>,
+) -> Vec<(OsString, OsString)> {
+    let mut environment: std::collections::BTreeMap<_, _> = base.into_iter().collect();
+    environment.extend(elevation);
+    environment.into_iter().collect()
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_identity(pid: libc::pid_t) -> Option<(libc::pid_t, [libc::uid_t; 4])> {
+    let status = std::fs::read(format!("/proc/{pid}/status")).ok()?;
+    parse_linux_process_identity(&status)
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_process_identity(status: &[u8]) -> Option<(libc::pid_t, [libc::uid_t; 4])> {
+    let text = std::str::from_utf8(status).ok()?;
+    let parent = text.lines().find_map(|line| {
+        line.strip_prefix("PPid:")
+            .and_then(|value| value.trim().parse().ok())
+    })?;
+    let uids = text.lines().find_map(|line| {
+        let mut values = line.strip_prefix("Uid:")?.split_whitespace();
+        Some([
+            values.next()?.parse().ok()?,
+            values.next()?.parse().ok()?,
+            values.next()?.parse().ok()?,
+            values.next()?.parse().ok()?,
+        ])
+    })?;
+    Some((parent, uids))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_environment(pid: libc::pid_t) -> Option<Vec<(OsString, OsString)>> {
+    let file = std::fs::File::open(format!("/proc/{pid}/environ")).ok()?;
+    let mut bytes = Vec::new();
+    file.take(1024 * 1024 + 1).read_to_end(&mut bytes).ok()?;
+    if bytes.len() > 1024 * 1024 {
+        return None;
+    }
+    Some(parse_allowlisted_environment(&bytes))
+}
+
+#[cfg(target_os = "linux")]
+fn parse_allowlisted_environment(bytes: &[u8]) -> Vec<(OsString, OsString)> {
+    let mut environment = std::collections::BTreeMap::new();
+    for item in bytes.split(|byte| *byte == 0) {
+        let Some(separator) = item.iter().position(|byte| *byte == b'=') else {
+            continue;
+        };
+        let (name, value) = item.split_at(separator);
+        if SESSION_ENVIRONMENT_KEYS
+            .iter()
+            .any(|candidate| candidate.as_bytes() == name)
+        {
+            environment.insert(
+                OsString::from_vec(name.to_vec()),
+                OsString::from_vec(value[1..].to_vec()),
+            );
+        }
+    }
+    environment.into_iter().collect()
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -290,6 +499,20 @@ fn passwd_buffer_size() -> usize {
 mod tests {
     use super::*;
 
+    fn test_user() -> InvokingUser {
+        InvokingUser {
+            uid: 1000,
+            gid: 1000,
+            name: OsString::from("paco"),
+            home: PathBuf::from("/home/paco"),
+            shell: OsString::from("/bin/sh"),
+            groups: vec![1000],
+            session_environment: vec![(OsString::from("EDITOR"), OsString::from("nvim"))],
+            xdg_config_home: None,
+            xdg_data_home: None,
+        }
+    }
+
     #[test]
     fn sudo_uid_accepts_only_non_root_numeric_ids() {
         assert_eq!(parse_non_root_uid(Some(OsStr::new("1000"))), Some(1000));
@@ -331,6 +554,99 @@ mod tests {
             invocation_context(0, Some(OsStr::new("invalid")), Some(OsStr::new("root"))),
             InvocationContext::ElevatedUnresolved
         ));
+    }
+
+    #[test]
+    fn elevated_environment_uses_invoking_user_value_not_root_value() {
+        assert_eq!(
+            env_var_for_context(
+                InvocationContext::Elevated(test_user()),
+                "EDITOR",
+                Some(OsString::from("root-editor")),
+            ),
+            Some(OsString::from("nvim"))
+        );
+        assert_eq!(
+            env_var_for_context(
+                InvocationContext::Elevated(test_user()),
+                "DISPLAY",
+                Some(OsString::from(":root")),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn normal_environment_remains_unchanged() {
+        assert_eq!(
+            env_var_for_context(
+                InvocationContext::Normal,
+                "EDITOR",
+                Some(OsString::from("nvim")),
+            ),
+            Some(OsString::from("nvim"))
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_environment_parser_keeps_only_allowlisted_values() {
+        let environment = parse_allowlisted_environment(
+            b"HOME=/root\0DISPLAY=:0\0EDITOR=nvim --clean\0SUDO_UID=1000\0",
+        );
+
+        assert_eq!(
+            environment,
+            vec![
+                (OsString::from("DISPLAY"), OsString::from(":0")),
+                (OsString::from("EDITOR"), OsString::from("nvim --clean")),
+            ]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_ancestor_environment_reads_current_user_parent() {
+        let uid = unsafe { libc::getuid() };
+        if uid == 0 {
+            return;
+        }
+        let environment = linux_ancestor_environment(uid)
+            .expect("non-root test process should have a same-user ancestor");
+        assert!(
+            environment.iter().any(|(name, _)| name == "PATH"),
+            "allowlisted parent environment should contain PATH"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn elevation_environment_overrides_stale_shell_values() {
+        let merged = merge_linux_environments(
+            vec![
+                (OsString::from("DISPLAY"), OsString::from(":0")),
+                (OsString::from("EDITOR"), OsString::from("vi")),
+            ],
+            vec![(OsString::from("EDITOR"), OsString::from("nvim"))],
+        );
+
+        assert_eq!(
+            merged,
+            vec![
+                (OsString::from("DISPLAY"), OsString::from(":0")),
+                (OsString::from("EDITOR"), OsString::from("nvim")),
+            ]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_status_parser_reads_parent_and_all_uids() {
+        assert_eq!(
+            parse_linux_process_identity(b"Name:\ttest\nPPid:\t42\nUid:\t1000\t0\t0\t0\n"),
+            Some((42, [1000, 0, 0, 0]))
+        );
+        assert_eq!(parse_linux_process_identity(b"Name:\ttest\n"), None);
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/src/config/invoking_user.rs
+++ b/src/config/invoking_user.rs
@@ -1,0 +1,135 @@
+#[cfg(unix)]
+use std::{
+    env,
+    ffi::{CStr, CString, OsStr},
+    mem,
+    os::unix::ffi::{OsStrExt, OsStringExt},
+    path::PathBuf,
+    ptr,
+};
+
+#[cfg(unix)]
+pub(super) fn home_dir() -> Option<PathBuf> {
+    elevated_home_dir(
+        unsafe { libc::geteuid() },
+        env::var_os("SUDO_UID").as_deref(),
+        env::var_os("DOAS_USER").as_deref(),
+    )
+    .or_else(dirs::home_dir)
+}
+
+#[cfg(not(unix))]
+pub(super) fn home_dir() -> Option<std::path::PathBuf> {
+    dirs::home_dir()
+}
+
+#[cfg(unix)]
+fn elevated_home_dir(
+    effective_uid: libc::uid_t,
+    sudo_uid: Option<&OsStr>,
+    doas_user: Option<&OsStr>,
+) -> Option<PathBuf> {
+    if effective_uid != 0 {
+        return None;
+    }
+    parse_non_root_uid(sudo_uid)
+        .and_then(passwd_home_by_uid)
+        .or_else(|| doas_user.and_then(passwd_home_by_name))
+}
+
+#[cfg(unix)]
+fn parse_non_root_uid(value: Option<&OsStr>) -> Option<libc::uid_t> {
+    let uid = value?.to_str()?.parse::<libc::uid_t>().ok()?;
+    (uid != 0).then_some(uid)
+}
+
+#[cfg(unix)]
+fn passwd_home_by_uid(uid: libc::uid_t) -> Option<PathBuf> {
+    passwd_home(|record, buffer, len, result| unsafe {
+        libc::getpwuid_r(uid, record, buffer, len, result)
+    })
+}
+
+#[cfg(unix)]
+fn passwd_home_by_name(name: &OsStr) -> Option<PathBuf> {
+    let bytes = name.as_bytes();
+    if bytes.is_empty() || bytes == b"root" {
+        return None;
+    }
+    let name = CString::new(bytes).ok()?;
+    passwd_home(|record, buffer, len, result| unsafe {
+        libc::getpwnam_r(name.as_ptr(), record, buffer, len, result)
+    })
+}
+
+#[cfg(unix)]
+fn passwd_home(
+    mut lookup: impl FnMut(
+        *mut libc::passwd,
+        *mut libc::c_char,
+        usize,
+        *mut *mut libc::passwd,
+    ) -> libc::c_int,
+) -> Option<PathBuf> {
+    let mut buffer = vec![0_u8; passwd_buffer_size()];
+    loop {
+        let mut record = unsafe { mem::zeroed::<libc::passwd>() };
+        let mut result = ptr::null_mut();
+        let status = lookup(
+            &mut record,
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            &mut result,
+        );
+        if status == libc::ERANGE && buffer.len() < 1024 * 1024 {
+            buffer.resize(buffer.len() * 2, 0);
+            continue;
+        }
+        if status != 0 || result.is_null() || record.pw_dir.is_null() {
+            return None;
+        }
+        let home = unsafe { CStr::from_ptr(record.pw_dir) }.to_bytes();
+        return (!home.is_empty())
+            .then(|| PathBuf::from(std::ffi::OsString::from_vec(home.to_vec())));
+    }
+}
+
+#[cfg(unix)]
+fn passwd_buffer_size() -> usize {
+    let size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    if size > 0 { size as usize } else { 16 * 1024 }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sudo_uid_accepts_only_non_root_numeric_ids() {
+        assert_eq!(parse_non_root_uid(Some(OsStr::new("1000"))), Some(1000));
+        assert_eq!(parse_non_root_uid(Some(OsStr::new("0"))), None);
+        assert_eq!(parse_non_root_uid(Some(OsStr::new("paco"))), None);
+        assert_eq!(parse_non_root_uid(None), None);
+    }
+
+    #[test]
+    fn non_root_process_ignores_elevation_metadata() {
+        assert_eq!(
+            elevated_home_dir(1000, Some(OsStr::new("1001")), Some(OsStr::new("paco"))),
+            None
+        );
+    }
+
+    #[test]
+    fn elevated_process_resolves_sudo_uid() {
+        let uid = unsafe { libc::getuid() };
+        if uid == 0 {
+            return;
+        }
+        let expected = passwd_home_by_uid(uid).expect("current user should have a home directory");
+        assert_eq!(
+            elevated_home_dir(0, Some(OsStr::new(&uid.to_string())), None),
+            Some(expected)
+        );
+    }
+}

--- a/src/config/invoking_user.rs
+++ b/src/config/invoking_user.rs
@@ -64,6 +64,15 @@ pub(crate) enum InvocationContext {
 }
 
 #[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum IdentityClaim {
+    Absent,
+    Root,
+    User(libc::uid_t),
+    Invalid,
+}
+
+#[cfg(unix)]
 static INVOCATION_CONTEXT: OnceLock<InvocationContext> = OnceLock::new();
 
 #[cfg(unix)]
@@ -74,17 +83,17 @@ pub(crate) fn context() -> &'static InvocationContext {
 #[cfg(unix)]
 fn detect_context() -> InvocationContext {
     let sudo_uid = env::var_os("SUDO_UID");
+    let sudo_user = env::var_os("SUDO_USER");
     let doas_user = env::var_os("DOAS_USER");
-    let has_elevation_metadata = sudo_uid.is_some()
-        || doas_user.is_some()
-        || ["SUDO_COMMAND", "SUDO_GID", "SUDO_USER"]
-            .into_iter()
-            .any(|name| env::var_os(name).is_some());
+    let has_other_sudo_metadata = ["SUDO_COMMAND", "SUDO_GID"]
+        .into_iter()
+        .any(|name| env::var_os(name).is_some());
     invocation_context(
         unsafe { libc::geteuid() },
         sudo_uid.as_deref(),
+        sudo_user.as_deref(),
+        has_other_sudo_metadata,
         doas_user.as_deref(),
-        has_elevation_metadata,
     )
 }
 
@@ -160,18 +169,23 @@ pub(crate) fn trash_data_dir() -> Option<PathBuf> {
 fn invocation_context(
     effective_uid: libc::uid_t,
     sudo_uid: Option<&OsStr>,
+    sudo_user: Option<&OsStr>,
+    has_other_sudo_metadata: bool,
     doas_user: Option<&OsStr>,
-    has_elevation_metadata: bool,
 ) -> InvocationContext {
     if effective_uid != 0 {
         return InvocationContext::Normal;
     }
-    if !has_elevation_metadata {
-        return InvocationContext::RootSession;
-    }
-    let user = parse_non_root_uid(sudo_uid)
-        .and_then(passwd_by_uid)
-        .or_else(|| doas_user.and_then(passwd_by_name));
+
+    let uid = match agreed_invoking_uid(
+        sudo_identity_claim(sudo_uid, sudo_user, has_other_sudo_metadata),
+        doas_identity_claim(doas_user),
+    ) {
+        Ok(None) => return InvocationContext::RootSession,
+        Ok(Some(uid)) => uid,
+        Err(()) => return InvocationContext::ElevatedUnresolved,
+    };
+    let user = passwd_by_uid(uid);
     let Some(mut user) = user else {
         return InvocationContext::ElevatedUnresolved;
     };
@@ -187,9 +201,60 @@ fn invocation_context(
 }
 
 #[cfg(unix)]
-fn parse_non_root_uid(value: Option<&OsStr>) -> Option<libc::uid_t> {
-    let uid = value?.to_str()?.parse::<libc::uid_t>().ok()?;
-    (uid != 0).then_some(uid)
+fn sudo_identity_claim(
+    sudo_uid: Option<&OsStr>,
+    sudo_user: Option<&OsStr>,
+    has_other_sudo_metadata: bool,
+) -> IdentityClaim {
+    if sudo_uid.is_none() && sudo_user.is_none() && !has_other_sudo_metadata {
+        return IdentityClaim::Absent;
+    }
+    let Some(uid) = parse_uid(sudo_uid) else {
+        return IdentityClaim::Invalid;
+    };
+    if sudo_user.and_then(uid_by_name) != Some(uid) {
+        return IdentityClaim::Invalid;
+    }
+    identity_claim(uid)
+}
+
+#[cfg(unix)]
+fn doas_identity_claim(doas_user: Option<&OsStr>) -> IdentityClaim {
+    match doas_user {
+        None => IdentityClaim::Absent,
+        Some(user) => uid_by_name(user)
+            .map(identity_claim)
+            .unwrap_or(IdentityClaim::Invalid),
+    }
+}
+
+#[cfg(unix)]
+fn identity_claim(uid: libc::uid_t) -> IdentityClaim {
+    if uid == 0 {
+        IdentityClaim::Root
+    } else {
+        IdentityClaim::User(uid)
+    }
+}
+
+#[cfg(unix)]
+fn agreed_invoking_uid(
+    sudo: IdentityClaim,
+    doas: IdentityClaim,
+) -> Result<Option<libc::uid_t>, ()> {
+    use IdentityClaim::{Absent, Root, User};
+
+    match (sudo, doas) {
+        (Absent, Absent | Root) | (Root, Absent | Root) => Ok(None),
+        (User(uid), Absent) | (Absent, User(uid)) => Ok(Some(uid)),
+        (User(sudo_uid), User(doas_uid)) if sudo_uid == doas_uid => Ok(Some(sudo_uid)),
+        _ => Err(()),
+    }
+}
+
+#[cfg(unix)]
+fn parse_uid(value: Option<&OsStr>) -> Option<libc::uid_t> {
+    value?.to_str()?.parse().ok()
 }
 
 #[cfg(unix)]
@@ -200,15 +265,16 @@ fn passwd_by_uid(uid: libc::uid_t) -> Option<InvokingUser> {
 }
 
 #[cfg(unix)]
-fn passwd_by_name(name: &OsStr) -> Option<InvokingUser> {
+fn uid_by_name(name: &OsStr) -> Option<libc::uid_t> {
     let bytes = name.as_bytes();
-    if bytes.is_empty() || bytes == b"root" {
+    if bytes.is_empty() {
         return None;
     }
     let name = CString::new(bytes).ok()?;
     passwd(|record, buffer, len, result| unsafe {
         libc::getpwnam_r(name.as_ptr(), record, buffer, len, result)
     })
+    .map(|user| user.uid)
 }
 
 #[cfg(unix)]
@@ -234,12 +300,7 @@ fn passwd(
             buffer.resize(buffer.len() * 2, 0);
             continue;
         }
-        if status != 0
-            || result.is_null()
-            || record.pw_dir.is_null()
-            || record.pw_name.is_null()
-            || record.pw_uid == 0
-        {
+        if status != 0 || result.is_null() || record.pw_dir.is_null() || record.pw_name.is_null() {
             return None;
         }
         let home = unsafe { CStr::from_ptr(record.pw_dir) }.to_bytes();
@@ -544,46 +605,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn sudo_uid_accepts_only_non_root_numeric_ids() {
-        assert_eq!(parse_non_root_uid(Some(OsStr::new("1000"))), Some(1000));
-        assert_eq!(parse_non_root_uid(Some(OsStr::new("0"))), None);
-        assert_eq!(parse_non_root_uid(Some(OsStr::new("paco"))), None);
-        assert_eq!(parse_non_root_uid(None), None);
-    }
-
-    #[test]
-    fn non_root_process_ignores_elevation_metadata() {
-        assert!(matches!(
-            invocation_context(
-                1000,
-                Some(OsStr::new("1001")),
-                Some(OsStr::new("paco")),
-                true,
-            ),
-            InvocationContext::Normal
-        ));
-    }
-
-    #[test]
-    fn root_without_elevation_metadata_is_root_session() {
-        assert!(matches!(
-            invocation_context(0, None, None, false),
-            InvocationContext::RootSession
-        ));
-    }
-
-    #[test]
-    fn elevated_process_resolves_sudo_uid() {
-        let uid = unsafe { libc::getuid() };
-        if uid == 0 {
-            return;
-        }
-        let expected = passwd_by_uid(uid).expect("current user should have a passwd record");
-        let InvocationContext::Elevated(actual) =
-            invocation_context(0, Some(OsStr::new(&uid.to_string())), None, true)
-        else {
-            panic!("current user should resolve as invoking user");
+    fn assert_elevated_user(context: InvocationContext, expected: &InvokingUser) {
+        let InvocationContext::Elevated(actual) = context else {
+            panic!("user should resolve as invoking user");
         };
         assert_eq!(actual.uid, expected.uid);
         assert_eq!(actual.gid, expected.gid);
@@ -593,16 +617,138 @@ mod tests {
     }
 
     #[test]
-    fn unresolved_elevated_context_does_not_become_normal() {
+    fn uid_parser_accepts_root_and_non_root_numeric_ids() {
+        assert_eq!(parse_uid(Some(OsStr::new("1000"))), Some(1000));
+        assert_eq!(parse_uid(Some(OsStr::new("0"))), Some(0));
+        assert_eq!(parse_uid(Some(OsStr::new("paco"))), None);
+        assert_eq!(parse_uid(None), None);
+    }
+
+    #[test]
+    fn non_root_process_ignores_elevation_metadata() {
         assert!(matches!(
             invocation_context(
-                0,
+                1000,
                 Some(OsStr::new("invalid")),
-                Some(OsStr::new("root")),
+                Some(OsStr::new("unknown")),
                 true,
+                Some(OsStr::new("unknown")),
             ),
-            InvocationContext::ElevatedUnresolved
+            InvocationContext::Normal
         ));
+    }
+
+    #[test]
+    fn direct_and_coherent_root_claims_are_root_sessions() {
+        let root = passwd_by_uid(0).expect("root should have a passwd record");
+        for context in [
+            invocation_context(0, None, None, false, None),
+            invocation_context(0, Some(OsStr::new("0")), Some(&root.name), false, None),
+            invocation_context(0, None, None, false, Some(&root.name)),
+            invocation_context(
+                0,
+                Some(OsStr::new("0")),
+                Some(&root.name),
+                false,
+                Some(&root.name),
+            ),
+        ] {
+            assert!(matches!(context, InvocationContext::RootSession));
+        }
+    }
+
+    #[test]
+    fn coherent_non_root_claims_resolve_the_invoking_user() {
+        let uid = unsafe { libc::getuid() };
+        if uid == 0 {
+            return;
+        }
+        let expected = passwd_by_uid(uid).expect("current user should have a passwd record");
+        let uid = uid.to_string();
+        for context in [
+            invocation_context(0, Some(OsStr::new(&uid)), Some(&expected.name), false, None),
+            invocation_context(0, None, None, false, Some(&expected.name)),
+            invocation_context(
+                0,
+                Some(OsStr::new(&uid)),
+                Some(&expected.name),
+                false,
+                Some(&expected.name),
+            ),
+        ] {
+            assert_elevated_user(context, &expected);
+        }
+    }
+
+    #[test]
+    fn sudo_claim_requires_matching_uid_and_user() {
+        let root = passwd_by_uid(0).expect("root should have a passwd record");
+        for (uid, user, other_metadata, expected) in [
+            (
+                Some(OsStr::new("0")),
+                Some(root.name.as_os_str()),
+                false,
+                IdentityClaim::Root,
+            ),
+            (
+                Some(OsStr::new("1")),
+                Some(root.name.as_os_str()),
+                false,
+                IdentityClaim::Invalid,
+            ),
+            (
+                Some(OsStr::new("invalid")),
+                Some(root.name.as_os_str()),
+                false,
+                IdentityClaim::Invalid,
+            ),
+            (Some(OsStr::new("0")), None, false, IdentityClaim::Invalid),
+            (
+                None,
+                Some(root.name.as_os_str()),
+                false,
+                IdentityClaim::Invalid,
+            ),
+            (None, None, true, IdentityClaim::Invalid),
+            (None, None, false, IdentityClaim::Absent),
+        ] {
+            assert_eq!(sudo_identity_claim(uid, user, other_metadata), expected);
+        }
+    }
+
+    #[test]
+    fn doas_claim_resolves_users_by_uid() {
+        let root = passwd_by_uid(0).expect("root should have a passwd record");
+        assert_eq!(doas_identity_claim(Some(&root.name)), IdentityClaim::Root);
+        assert_eq!(doas_identity_claim(None), IdentityClaim::Absent);
+        assert_eq!(
+            doas_identity_claim(Some(OsStr::new("elio-user-that-does-not-exist"))),
+            IdentityClaim::Invalid
+        );
+    }
+
+    #[test]
+    fn identity_claims_must_be_absent_or_coherent() {
+        use IdentityClaim::{Absent, Invalid, Root, User};
+
+        for (sudo, doas, expected) in [
+            (Absent, Absent, Ok(None)),
+            (Root, Absent, Ok(None)),
+            (Absent, Root, Ok(None)),
+            (Root, Root, Ok(None)),
+            (User(1000), Absent, Ok(Some(1000))),
+            (Absent, User(1000), Ok(Some(1000))),
+            (User(1000), User(1000), Ok(Some(1000))),
+            (Root, User(1000), Err(())),
+            (User(1000), Root, Err(())),
+            (User(1000), User(1001), Err(())),
+            (Invalid, User(1000), Err(())),
+            (User(1000), Invalid, Err(())),
+            (Invalid, Absent, Err(())),
+            (Absent, Invalid, Err(())),
+        ] {
+            assert_eq!(agreed_invoking_uid(sudo, doas), expected);
+        }
     }
 
     #[test]

--- a/src/config/invoking_user.rs
+++ b/src/config/invoking_user.rs
@@ -17,6 +17,8 @@ pub(crate) const SESSION_ENVIRONMENT_KEYS: &[&str] = &[
     "DESKTOP_SESSION",
     "DISPLAY",
     "EDITOR",
+    "ELIO_ZOXIDE_OPTS",
+    "FZF_DEFAULT_OPTS",
     "PATH",
     "VISUAL",
     "WAYLAND_DISPLAY",
@@ -30,6 +32,11 @@ pub(crate) const SESSION_ENVIRONMENT_KEYS: &[&str] = &[
     "XDG_RUNTIME_DIR",
     "XDG_SESSION_DESKTOP",
     "XDG_SESSION_TYPE",
+    "_ZO_DATA_DIR",
+    "_ZO_ECHO",
+    "_ZO_EXCLUDE_DIRS",
+    "_ZO_MAXAGE",
+    "_ZO_RESOLVE_SYMLINKS",
 ];
 
 #[cfg(unix)]
@@ -592,7 +599,7 @@ mod tests {
     #[test]
     fn linux_environment_parser_keeps_only_allowlisted_values() {
         let environment = parse_allowlisted_environment(
-            b"HOME=/root\0DISPLAY=:0\0EDITOR=nvim --clean\0SUDO_UID=1000\0",
+            b"HOME=/root\0DISPLAY=:0\0EDITOR=nvim --clean\0ELIO_ZOXIDE_OPTS=--no-mouse\0FZF_DEFAULT_OPTS=--height=40%\0SUDO_UID=1000\0",
         );
 
         assert_eq!(
@@ -600,8 +607,32 @@ mod tests {
             vec![
                 (OsString::from("DISPLAY"), OsString::from(":0")),
                 (OsString::from("EDITOR"), OsString::from("nvim --clean")),
+                (
+                    OsString::from("ELIO_ZOXIDE_OPTS"),
+                    OsString::from("--no-mouse"),
+                ),
+                (
+                    OsString::from("FZF_DEFAULT_OPTS"),
+                    OsString::from("--height=40%"),
+                ),
             ]
         );
+    }
+
+    #[test]
+    fn zoxide_environment_values_are_allowlisted() {
+        for name in [
+            "_ZO_DATA_DIR",
+            "_ZO_ECHO",
+            "_ZO_EXCLUDE_DIRS",
+            "_ZO_MAXAGE",
+            "_ZO_RESOLVE_SYMLINKS",
+        ] {
+            assert!(
+                SESSION_ENVIRONMENT_KEYS.contains(&name),
+                "missing zoxide environment value: {name}"
+            );
+        }
     }
 
     #[cfg(target_os = "linux")]

--- a/src/config/invoking_user.rs
+++ b/src/config/invoking_user.rs
@@ -15,6 +15,7 @@ pub(crate) struct InvokingUser {
     pub(crate) gid: libc::gid_t,
     pub(crate) name: OsString,
     pub(crate) home: PathBuf,
+    pub(crate) shell: OsString,
     pub(crate) groups: Vec<libc::gid_t>,
     pub(crate) xdg_data_home: Option<PathBuf>,
 }
@@ -157,6 +158,11 @@ fn passwd(
         }
         let home = unsafe { CStr::from_ptr(record.pw_dir) }.to_bytes();
         let name = unsafe { CStr::from_ptr(record.pw_name) }.to_bytes();
+        let shell = if record.pw_shell.is_null() {
+            &[][..]
+        } else {
+            unsafe { CStr::from_ptr(record.pw_shell) }.to_bytes()
+        };
         if home.is_empty() || name.is_empty() {
             return None;
         }
@@ -165,6 +171,11 @@ fn passwd(
             gid: record.pw_gid,
             name: OsString::from_vec(name.to_vec()),
             home: PathBuf::from(OsString::from_vec(home.to_vec())),
+            shell: if shell.is_empty() {
+                OsString::from("/bin/sh")
+            } else {
+                OsString::from_vec(shell.to_vec())
+            },
             groups: vec![record.pw_gid],
             xdg_data_home: None,
         });
@@ -310,6 +321,7 @@ mod tests {
         assert_eq!(actual.uid, expected.uid);
         assert_eq!(actual.gid, expected.gid);
         assert_eq!(actual.home, expected.home);
+        assert_eq!(actual.shell, expected.shell);
         assert!(actual.groups.contains(&actual.gid));
     }
 

--- a/src/config/invoking_user.rs
+++ b/src/config/invoking_user.rs
@@ -138,13 +138,13 @@ pub(crate) fn home_dir() -> Option<std::path::PathBuf> {
 }
 
 pub(crate) fn trash_home_dir() -> Option<std::path::PathBuf> {
-    #[cfg(all(unix, not(target_os = "macos")))]
+    #[cfg(unix)]
     return trash_home_for_context(context());
-    #[cfg(any(not(unix), target_os = "macos"))]
+    #[cfg(not(unix))]
     return dirs::home_dir();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 fn trash_home_for_context(context: &InvocationContext) -> Option<PathBuf> {
     match context {
         InvocationContext::Normal | InvocationContext::RootSession => dirs::home_dir(),
@@ -899,12 +899,19 @@ mod tests {
         assert_eq!(parse_linux_process_identity(b"Name:\ttest\n"), None);
     }
 
-    #[cfg(not(target_os = "macos"))]
     #[test]
     fn unresolved_elevated_context_has_no_trash_home() {
         assert_eq!(
             trash_home_for_context(&InvocationContext::ElevatedUnresolved),
             None
+        );
+    }
+
+    #[test]
+    fn elevated_context_uses_invoking_user_trash_home() {
+        assert_eq!(
+            trash_home_for_context(&InvocationContext::Elevated(test_user())),
+            Some(PathBuf::from("/home/paco"))
         );
     }
 

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -1,4 +1,8 @@
 use super::Config;
+#[cfg(unix)]
+use super::invoking_user::InvocationContext;
+#[cfg(unix)]
+use std::path::Path;
 use std::{env, fs, io, path::PathBuf, sync::OnceLock};
 
 static ACTIVE_CONFIG: OnceLock<Config> = OnceLock::new();
@@ -11,39 +15,72 @@ pub(super) fn active_config() -> &'static Config {
     ACTIVE_CONFIG.get_or_init(Config::default_config)
 }
 
-pub(crate) fn config_dir() -> Option<PathBuf> {
-    // XDG_CONFIG_HOME is honoured on all platforms so developers can redirect
-    // the config location regardless of OS.
-    if let Some(config_home) = env::var_os("XDG_CONFIG_HOME") {
-        return Some(PathBuf::from(config_home).join("elio"));
+fn config_home() -> Option<PathBuf> {
+    #[cfg(unix)]
+    {
+        let process_xdg_home = env::var_os("XDG_CONFIG_HOME").map(PathBuf::from);
+        let process_home = dirs::home_dir();
+        config_home_for_context(
+            super::invoking_user::context(),
+            process_xdg_home.as_deref(),
+            process_home.as_deref(),
+        )
     }
+
+    #[cfg(windows)]
+    {
+        // XDG_CONFIG_HOME is honoured on Windows so developers can redirect
+        // the config location regardless of OS.
+        if let Some(config_home) = env::var_os("XDG_CONFIG_HOME") {
+            return Some(PathBuf::from(config_home));
+        }
+        dirs::config_dir()
+    }
+}
+
+pub(crate) fn config_dir() -> Option<PathBuf> {
+    config_home().map(|home| home.join("elio"))
+}
+
+#[cfg(unix)]
+fn config_home_for_context(
+    context: &InvocationContext,
+    process_xdg_home: Option<&Path>,
+    process_home: Option<&Path>,
+) -> Option<PathBuf> {
+    match context {
+        InvocationContext::Normal | InvocationContext::RootSession => {
+            platform_config_home(process_xdg_home, process_home)
+        }
+        InvocationContext::Elevated(user) => {
+            platform_config_home(user.xdg_config_home.as_deref(), Some(&user.home))
+        }
+        InvocationContext::ElevatedUnresolved => None,
+    }
+}
+
+#[cfg(unix)]
+fn platform_config_home(xdg_home: Option<&Path>, home: Option<&Path>) -> Option<PathBuf> {
+    if let Some(xdg_home) = xdg_home {
+        return Some(xdg_home.to_path_buf());
+    }
+    let home = home?;
 
     #[cfg(target_os = "macos")]
     {
         // Prefer XDG-style config on macOS only when it contains Elio config
         // files, avoiding empty ~/.config/elio directories shadowing the native
         // Application Support location.
-        if let Some(home) = super::invoking_user::home_dir() {
-            let xdg_dir = home.join(".config/elio");
-            if xdg_dir.join("config.toml").is_file() || xdg_dir.join("theme.toml").is_file() {
-                return Some(xdg_dir);
-            }
+        let xdg_home = home.join(".config");
+        let xdg_dir = xdg_home.join("elio");
+        if xdg_dir.join("config.toml").is_file() || xdg_dir.join("theme.toml").is_file() {
+            return Some(xdg_home);
         }
+        return Some(home.join("Library/Application Support"));
     }
 
-    // dirs::config_dir() returns:
-    //   Linux/BSD : $HOME/.config
-    //   macOS     : $HOME/Library/Application Support
-    //   Windows   : %APPDATA% (Roaming)
-    #[cfg(all(unix, not(target_os = "macos")))]
-    return super::invoking_user::home_dir().map(|home| home.join(".config/elio"));
-
-    #[cfg(target_os = "macos")]
-    return super::invoking_user::home_dir()
-        .map(|home| home.join("Library/Application Support/elio"));
-
-    #[cfg(windows)]
-    dirs::config_dir().map(|dir| dir.join("elio"))
+    #[cfg(not(target_os = "macos"))]
+    Some(home.join(".config"))
 }
 
 fn load_config_from_disk() -> Config {
@@ -76,4 +113,70 @@ fn load_config_from_disk() -> Config {
 
 fn config_path() -> Option<PathBuf> {
     config_dir().map(|dir| dir.join("config.toml"))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::config::InvokingUser;
+    use std::ffi::OsString;
+
+    fn test_user(xdg_config_home: Option<&str>) -> InvokingUser {
+        InvokingUser {
+            uid: 1000,
+            gid: 1000,
+            name: OsString::from("paco"),
+            home: PathBuf::from("/home/paco"),
+            shell: OsString::from("/bin/sh"),
+            groups: vec![1000],
+            session_environment: Vec::new(),
+            xdg_config_home: xdg_config_home.map(PathBuf::from),
+            xdg_data_home: None,
+        }
+    }
+
+    #[test]
+    fn config_home_follows_invocation_context() {
+        let root_default = if cfg!(target_os = "macos") {
+            Path::new("/root/Library/Application Support")
+        } else {
+            Path::new("/root/.config")
+        };
+        let user_default = if cfg!(target_os = "macos") {
+            Path::new("/home/paco/Library/Application Support")
+        } else {
+            Path::new("/home/paco/.config")
+        };
+        let process_xdg = Some(Path::new("/root/custom"));
+        let cases = [
+            (
+                InvocationContext::Normal,
+                process_xdg,
+                Some(Path::new("/root/custom")),
+            ),
+            (
+                InvocationContext::RootSession,
+                process_xdg,
+                Some(Path::new("/root/custom")),
+            ),
+            (InvocationContext::Normal, None, Some(root_default)),
+            (InvocationContext::RootSession, None, Some(root_default)),
+            (
+                InvocationContext::Elevated(test_user(Some("/home/paco/custom-config"))),
+                process_xdg,
+                Some(Path::new("/home/paco/custom-config")),
+            ),
+            (
+                InvocationContext::Elevated(test_user(None)),
+                process_xdg,
+                Some(user_default),
+            ),
+            (InvocationContext::ElevatedUnresolved, process_xdg, None),
+        ];
+
+        for (context, process_xdg, expected) in cases {
+            let actual = config_home_for_context(&context, process_xdg, Some(Path::new("/root")));
+            assert_eq!(actual.as_deref(), expected, "context: {context:?}");
+        }
+    }
 }

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -23,7 +23,7 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
         // Prefer XDG-style config on macOS only when it contains Elio config
         // files, avoiding empty ~/.config/elio directories shadowing the native
         // Application Support location.
-        if let Some(home) = dirs::home_dir() {
+        if let Some(home) = super::invoking_user::home_dir() {
             let xdg_dir = home.join(".config/elio");
             if xdg_dir.join("config.toml").is_file() || xdg_dir.join("theme.toml").is_file() {
                 return Some(xdg_dir);
@@ -35,6 +35,14 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     //   Linux/BSD : $HOME/.config
     //   macOS     : $HOME/Library/Application Support
     //   Windows   : %APPDATA% (Roaming)
+    #[cfg(all(unix, not(target_os = "macos")))]
+    return super::invoking_user::home_dir().map(|home| home.join(".config/elio"));
+
+    #[cfg(target_os = "macos")]
+    return super::invoking_user::home_dir()
+        .map(|home| home.join("Library/Application Support/elio"));
+
+    #[cfg(windows)]
     dirs::config_dir().map(|dir| dir.join("elio"))
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod goto;
+mod invoking_user;
 mod keys;
 mod layout;
 mod loading;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,9 +11,12 @@ mod ui;
 
 use serde::Deserialize;
 
+pub(crate) use self::invoking_user::env_var as invoking_user_env_var;
+
 #[cfg(unix)]
 pub(crate) use self::invoking_user::{
-    InvocationContext, InvokingUser, context as invoking_user_context,
+    InvocationContext, InvokingUser, SESSION_ENVIRONMENT_KEYS, context as invoking_user_context,
+    user_environment_value,
 };
 
 #[cfg(all(unix, not(target_os = "macos")))]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,6 +53,9 @@ struct ConfigFile {
 }
 
 pub(crate) fn initialize() {
+    #[cfg(unix)]
+    // Snapshot the invocation context before loading config or starting workers.
+    let _ = invoking_user::context();
     loading::initialize();
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 
 pub(crate) use self::{
     goto::{BuiltinGoto, GotoConfig, GotoEntrySpec},
+    invoking_user::home_dir as invoking_user_home_dir,
     keys::{Action, ChooserKeyAction, KeyBindings, KeyContext, KeyList, normalized_plain_key_char},
     layout::{LayoutConfig, PaneWeights},
     loading::config_dir,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,9 +11,17 @@ mod ui;
 
 use serde::Deserialize;
 
+#[cfg(unix)]
+pub(crate) use self::invoking_user::{
+    InvocationContext, InvokingUser, context as invoking_user_context,
+};
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(crate) use self::invoking_user::trash_data_dir;
+
 pub(crate) use self::{
     goto::{BuiltinGoto, GotoConfig, GotoEntrySpec},
-    invoking_user::home_dir as invoking_user_home_dir,
+    invoking_user::{home_dir as invoking_user_home_dir, trash_home_dir},
     keys::{Action, ChooserKeyAction, KeyBindings, KeyContext, KeyList, normalized_plain_key_char},
     layout::{LayoutConfig, PaneWeights},
     loading::config_dir,

--- a/src/config/places.rs
+++ b/src/config/places.rs
@@ -203,9 +203,10 @@ impl BuiltinPlace {
 
 pub(super) fn expand_custom_place_path(path: &str) -> anyhow::Result<PathBuf> {
     let expanded = if path == "~" {
-        crate::fs::home_dir().ok_or_else(|| anyhow::anyhow!("could not resolve home directory"))?
+        super::invoking_user_home_dir()
+            .ok_or_else(|| anyhow::anyhow!("could not resolve home directory"))?
     } else if let Some(rest) = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\")) {
-        crate::fs::home_dir()
+        super::invoking_user_home_dir()
             .ok_or_else(|| anyhow::anyhow!("could not resolve home directory"))?
             .join(rest)
     } else {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -45,6 +45,8 @@ pub(crate) use format::{
     rect_contains, sanitize_terminal_text, symlink_target_display_label,
 };
 pub(crate) use item_count::count_directory_items;
+#[cfg(target_os = "macos")]
+pub(crate) use opener::detached_open;
 #[cfg(test)]
 pub(crate) use opener::set_open_in_system_capture_for_test;
 pub(crate) use opener::{detached_open_command, open_in_system};

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -48,7 +48,7 @@ pub(crate) use item_count::count_directory_items;
 #[cfg(test)]
 pub(crate) use opener::set_open_in_system_capture_for_test;
 pub(crate) use opener::{detached_open_command, open_in_system};
-pub(crate) use places::{build_sidebar_rows, home_dir, trash_dir};
+pub(crate) use places::{build_sidebar_rows, trash_dir};
 pub(crate) use restore::restore_trash_item;
 #[cfg(target_os = "macos")]
 pub(crate) use restore::{remove_restore_origins, save_restore_origins};

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -55,7 +55,7 @@ pub(crate) use restore::restore_trash_item;
 #[cfg(target_os = "macos")]
 pub(crate) use restore::{
     remove_restore_origins, remove_restore_origins_checked, restore_trash_item_checked_metadata,
-    save_restore_origins,
+    save_restore_origins_checked,
 };
 pub(crate) use sort::natural_cmp;
 pub(crate) use watch::{

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -53,7 +53,10 @@ pub(crate) use opener::{detached_open_command, open_in_system};
 pub(crate) use places::{build_sidebar_rows, trash_dir};
 pub(crate) use restore::restore_trash_item;
 #[cfg(target_os = "macos")]
-pub(crate) use restore::{remove_restore_origins, save_restore_origins};
+pub(crate) use restore::{
+    remove_restore_origins, remove_restore_origins_checked, restore_trash_item_checked_metadata,
+    save_restore_origins,
+};
 pub(crate) use sort::natural_cmp;
 pub(crate) use watch::{
     DirectoryWatchEvent, DirectoryWatcher, directory_watch_debounce, event_affects_visible_entries,

--- a/src/fs/opener.rs
+++ b/src/fs/opener.rs
@@ -149,6 +149,7 @@ fn spawn_with_deadline(
 ) -> io::Result<()> {
     use std::time::Instant;
 
+    prepare_external_open_command(&mut command)?;
     let mut child = command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -216,6 +217,7 @@ fn detached_spawn_with_deadline(
 ) -> io::Result<()> {
     use std::time::Instant;
 
+    prepare_external_open_command(command)?;
     prepare_detached_command(command);
     let mut child = command.spawn()?;
 
@@ -251,8 +253,19 @@ fn prepare_detached_command(command: &mut Command) {
     }
 }
 
+#[cfg(unix)]
+fn prepare_external_open_command(command: &mut Command) -> io::Result<()> {
+    crate::invoking_user_command::prepare_external(command, None)
+}
+
+#[cfg(not(unix))]
+fn prepare_external_open_command(_command: &mut Command) -> io::Result<()> {
+    Ok(())
+}
+
 #[cfg(target_os = "macos")]
 fn status_spawn(command: &mut Command) -> io::Result<()> {
+    prepare_external_open_command(command)?;
     command.stdin(Stdio::null());
     command.stdout(Stdio::null());
     command.stderr(Stdio::null());

--- a/src/fs/places/mod.rs
+++ b/src/fs/places/mod.rs
@@ -5,4 +5,4 @@ mod resolution;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use self::resolution::{build_sidebar_rows, home_dir, trash_dir};
+pub(crate) use self::resolution::{build_sidebar_rows, trash_dir};

--- a/src/fs/places/resolution.rs
+++ b/src/fs/places/resolution.rs
@@ -3,6 +3,8 @@ use crate::{
     config::{BuiltinPlace, PlaceEntrySpec, PlacesConfig},
     core::{SidebarItem, SidebarItemKind, SidebarRow},
 };
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+use std::{collections::HashMap, ffi::OsString, os::unix::ffi::OsStringExt};
 use std::{
     collections::HashSet,
     fs,
@@ -36,13 +38,13 @@ pub(crate) fn home_dir() -> Option<PathBuf> {
 }
 
 pub(crate) fn build_sidebar_rows() -> Vec<SidebarRow> {
-    let home = home_dir().unwrap_or_else(|| {
+    let home = crate::config::invoking_user_home_dir().unwrap_or_else(|| {
         #[cfg(windows)]
         return PathBuf::from("C:\\");
         #[cfg(not(windows))]
         return PathBuf::from("/");
     });
-    let context = system_place_resolution_context(home);
+    let context = system_place_resolution_context(home, dirs::home_dir());
     build_sidebar_rows_with_context(crate::config::places(), &context)
 }
 
@@ -71,22 +73,148 @@ pub(super) fn build_sidebar_rows_with_context(
     rows
 }
 
-fn system_place_resolution_context(home: PathBuf) -> PlaceResolutionContext {
+fn system_place_resolution_context(
+    home: PathBuf,
+    process_home: Option<PathBuf>,
+) -> PlaceResolutionContext {
+    #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+    let user_dirs = if process_home.as_deref() != Some(&home) {
+        read_user_dirs(&home)
+    } else {
+        Default::default()
+    };
+    #[cfg(any(not(unix), target_os = "macos", target_os = "ios"))]
+    let user_dirs = ();
+
+    let personal_dir = |current, key, fallback| {
+        resolve_personal_dir(
+            &home,
+            process_home.as_deref(),
+            current,
+            configured_user_dir(&user_dirs, key),
+            platform_personal_dir_fallback(fallback),
+        )
+    };
+
     PlaceResolutionContext {
-        desktop: dirs::desktop_dir().filter(|path| path.exists()),
-        documents: dirs::document_dir().filter(|path| path.exists()),
-        downloads: dirs::download_dir().filter(|path| path.exists()),
-        pictures: dirs::picture_dir().filter(|path| path.exists()),
-        music: dirs::audio_dir().filter(|path| path.exists()),
-        videos: dirs::video_dir().filter(|path| path.exists()),
+        desktop: personal_dir(dirs::desktop_dir(), "DESKTOP", "Desktop"),
+        documents: personal_dir(dirs::document_dir(), "DOCUMENTS", "Documents"),
+        downloads: personal_dir(dirs::download_dir(), "DOWNLOAD", "Downloads"),
+        pictures: personal_dir(dirs::picture_dir(), "PICTURES", "Pictures"),
+        music: personal_dir(dirs::audio_dir(), "MUSIC", "Music"),
+        videos: personal_dir(
+            dirs::video_dir(),
+            "VIDEOS",
+            if cfg!(target_os = "macos") {
+                "Movies"
+            } else {
+                "Videos"
+            },
+        ),
         root: if cfg!(unix) {
             Some(PathBuf::from("/"))
         } else {
             None
         },
-        trash: trash_dir(&home),
+        trash: process_home.as_deref().and_then(trash_dir),
         home,
     }
+}
+
+pub(super) fn resolve_personal_dir(
+    home: &Path,
+    process_home: Option<&Path>,
+    current: Option<PathBuf>,
+    configured: Option<PathBuf>,
+    fallback: Option<&str>,
+) -> Option<PathBuf> {
+    if process_home == Some(home) {
+        current
+    } else {
+        configured.or_else(|| fallback.map(|fallback| home.join(fallback)))
+    }
+    .filter(|path| path.exists())
+}
+
+#[cfg(any(not(unix), target_os = "macos", target_os = "ios"))]
+fn platform_personal_dir_fallback(fallback: &str) -> Option<&str> {
+    Some(fallback)
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+fn platform_personal_dir_fallback(_fallback: &str) -> Option<&str> {
+    None
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+fn configured_user_dir(user_dirs: &HashMap<String, PathBuf>, key: &str) -> Option<PathBuf> {
+    user_dirs.get(key).cloned()
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+fn read_user_dirs(home: &Path) -> HashMap<String, PathBuf> {
+    let Ok(contents) = fs::read(home.join(".config/user-dirs.dirs")) else {
+        return HashMap::new();
+    };
+    contents
+        .split(|byte| *byte == b'\n')
+        .filter_map(|line| parse_user_dir(line, home))
+        .collect()
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+pub(super) fn parse_user_dir(line: &[u8], home: &Path) -> Option<(String, PathBuf)> {
+    let separator = line.iter().position(|byte| *byte == b'=')?;
+    let (key, value) = (&line[..separator], &line[separator + 1..]);
+    let key = trim_ascii(key);
+    let key = key.strip_prefix(b"XDG_")?.strip_suffix(b"_DIR")?;
+    let key = std::str::from_utf8(key).ok()?.to_string();
+    let value = trim_ascii(value).strip_prefix(b"\"")?;
+    let (base, value) = if let Some(relative) = value.strip_prefix(b"$HOME/") {
+        (Some(home), relative)
+    } else if value.starts_with(b"/") {
+        (None, value)
+    } else {
+        return None;
+    };
+    let value = OsString::from_vec(unescape_quoted_user_dir(value)?);
+    if value.is_empty() {
+        return None;
+    }
+    let path = base.map_or_else(|| PathBuf::from(&value), |base| base.join(&value));
+    Some((key, path))
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+fn trim_ascii(value: &[u8]) -> &[u8] {
+    let start = value
+        .iter()
+        .position(|byte| !matches!(byte, b' ' | b'\t' | b'\r'))
+        .unwrap_or(value.len());
+    let end = value
+        .iter()
+        .rposition(|byte| !matches!(byte, b' ' | b'\t' | b'\r'))
+        .map_or(start, |index| index + 1);
+    &value[start..end]
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+fn unescape_quoted_user_dir(value: &[u8]) -> Option<Vec<u8>> {
+    let mut unescaped = Vec::with_capacity(value.len());
+    let mut bytes = value.iter().copied();
+    while let Some(byte) = bytes.next() {
+        match byte {
+            b'"' => return Some(unescaped),
+            b'\\' => unescaped.push(bytes.next()?),
+            _ => unescaped.push(byte),
+        }
+    }
+    None
+}
+
+#[cfg(any(not(unix), target_os = "macos", target_os = "ios"))]
+fn configured_user_dir(_user_dirs: &(), _key: &str) -> Option<PathBuf> {
+    None
 }
 
 fn build_pinned_sidebar_items(

--- a/src/fs/places/resolution.rs
+++ b/src/fs/places/resolution.rs
@@ -412,9 +412,10 @@ pub(crate) fn trash_dir(home: &Path) -> Option<PathBuf> {
     } else {
         Some(home.join(".local/share"))
     };
-    #[cfg(any(not(unix), target_os = "macos"))]
+    #[cfg(not(unix))]
     let data_dir = dirs::data_dir();
 
+    #[cfg(not(target_os = "macos"))]
     if let Some(data_dir) = data_dir {
         let xdg_trash = data_dir.join("Trash/files");
         if xdg_trash.exists() {
@@ -422,7 +423,7 @@ pub(crate) fn trash_dir(home: &Path) -> Option<PathBuf> {
         }
     }
 
-    // macOS: ~/.Trash (freedesktop path above won't exist there)
+    // macOS: always use the selected user's ~/.Trash.
     let mac_trash = home.join(".Trash");
     if mac_trash.exists() {
         return Some(mac_trash);

--- a/src/fs/places/resolution.rs
+++ b/src/fs/places/resolution.rs
@@ -28,15 +28,6 @@ pub(super) struct PlaceResolutionContext {
     pub(super) trash: Option<PathBuf>,
 }
 
-/// Returns the current user's home directory.
-///
-/// Delegates to the [`dirs`] crate, which reads `$HOME` on Unix and
-/// `%USERPROFILE%` / `{FOLDERID_Profile}` on Windows. Returns `None` only in
-/// the unlikely event that none of the relevant system APIs succeed.
-pub(crate) fn home_dir() -> Option<PathBuf> {
-    dirs::home_dir()
-}
-
 pub(crate) fn build_sidebar_rows() -> Vec<SidebarRow> {
     let home = crate::config::invoking_user_home_dir().unwrap_or_else(|| {
         #[cfg(windows)]
@@ -116,7 +107,7 @@ fn system_place_resolution_context(
         } else {
             None
         },
-        trash: process_home.as_deref().and_then(trash_dir),
+        trash: crate::config::trash_home_dir().and_then(|home| trash_dir(&home)),
         home,
     }
 }
@@ -415,9 +406,16 @@ pub(super) fn normalize_absolute_path(path: &Path) -> PathBuf {
 /// - **Windows:** always returns `None`. The Recycle Bin is a virtual shell folder
 ///   that is not practically accessible as a regular filesystem path.
 pub(crate) fn trash_dir(home: &Path) -> Option<PathBuf> {
-    // dirs::data_dir() honours $XDG_DATA_HOME on Linux/BSD, returns
-    // ~/Library/Application Support on macOS, and %APPDATA% on Windows.
-    if let Some(data_dir) = dirs::data_dir() {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let data_dir = if crate::config::trash_home_dir().as_deref() == Some(home) {
+        crate::config::trash_data_dir()
+    } else {
+        Some(home.join(".local/share"))
+    };
+    #[cfg(any(not(unix), target_os = "macos"))]
+    let data_dir = dirs::data_dir();
+
+    if let Some(data_dir) = data_dir {
         let xdg_trash = data_dir.join("Trash/files");
         if xdg_trash.exists() {
             return Some(xdg_trash);

--- a/src/fs/places/tests.rs
+++ b/src/fs/places/tests.rs
@@ -1,4 +1,8 @@
-use super::resolution::{PlaceResolutionContext, build_sidebar_rows_with_context};
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+use super::resolution::parse_user_dir;
+use super::resolution::{
+    PlaceResolutionContext, build_sidebar_rows_with_context, resolve_personal_dir,
+};
 use crate::{
     config::{BuiltinPlace, PlaceEntrySpec, PlacesConfig},
     core::{SidebarItemKind, SidebarRow},
@@ -34,6 +38,130 @@ fn context_for(root: &Path) -> PlaceResolutionContext {
         root: None,
         trash: Some(trash),
     }
+}
+
+#[test]
+fn personal_dir_uses_current_resolution_for_normal_sessions() {
+    let home = temp_path("normal-home");
+    let localized = home.join("Descargas");
+    fs::create_dir_all(&localized).expect("failed to create localized place");
+
+    assert_eq!(
+        resolve_personal_dir(
+            &home,
+            Some(&home),
+            Some(localized.clone()),
+            None,
+            Some("Downloads"),
+        ),
+        Some(localized)
+    );
+
+    fs::remove_dir_all(home).expect("failed to remove temp home");
+}
+
+#[test]
+fn personal_dir_uses_invoking_home_when_process_home_differs() {
+    let root = temp_path("elevated-home");
+    let home = root.join("paco");
+    let downloads = home.join("Downloads");
+    fs::create_dir_all(&downloads).expect("failed to create invoking-user downloads");
+
+    assert_eq!(
+        resolve_personal_dir(
+            &home,
+            Some(Path::new("/root")),
+            Some(PathBuf::from("/root/Downloads")),
+            None,
+            Some("Downloads"),
+        ),
+        Some(downloads)
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn personal_dir_prefers_invoking_users_configured_directory() {
+    let root = temp_path("configured-home");
+    let home = root.join("paco");
+    let downloads = home.join("Descargas");
+    fs::create_dir_all(&downloads).expect("failed to create configured downloads");
+
+    assert_eq!(
+        resolve_personal_dir(
+            &home,
+            Some(Path::new("/root")),
+            Some(PathBuf::from("/root/Downloads")),
+            Some(downloads.clone()),
+            Some("Downloads"),
+        ),
+        Some(downloads)
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn personal_dir_does_not_invent_missing_elevated_unix_place() {
+    let root = temp_path("missing-place");
+    let home = root.join("paco");
+    let downloads = home.join("Downloads");
+    fs::create_dir_all(&downloads).expect("failed to create conventional downloads");
+
+    assert_eq!(
+        resolve_personal_dir(
+            &home,
+            Some(Path::new("/root")),
+            Some(PathBuf::from("/root/Downloads")),
+            None,
+            None,
+        ),
+        None
+    );
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+#[test]
+fn user_dir_parser_handles_home_relative_absolute_and_escaped_paths() {
+    let home = Path::new("/home/paco");
+    assert_eq!(
+        parse_user_dir(b"XDG_DOWNLOAD_DIR=\"$HOME/Descargas\"", home),
+        Some(("DOWNLOAD".to_string(), home.join("Descargas")))
+    );
+    assert_eq!(
+        parse_user_dir(b"XDG_DOCUMENTS_DIR=\"/srv/paco/docs\"", home),
+        Some(("DOCUMENTS".to_string(), PathBuf::from("/srv/paco/docs")))
+    );
+    assert_eq!(
+        parse_user_dir(b"XDG_MUSIC_DIR=\"$HOME/My\\ Music\"", home),
+        Some(("MUSIC".to_string(), home.join("My Music")))
+    );
+    assert_eq!(
+        parse_user_dir(b"XDG_PICTURES_DIR=\"$HOME/My\\\" Photos\" # comment", home),
+        Some(("PICTURES".to_string(), home.join("My\" Photos")))
+    );
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+#[test]
+fn user_dir_parser_rejects_disabled_relative_and_malformed_paths() {
+    let home = Path::new("/home/paco");
+    assert_eq!(parse_user_dir(b"XDG_DOWNLOAD_DIR=\"$HOME/\"", home), None);
+    assert_eq!(
+        parse_user_dir(b"XDG_DOWNLOAD_DIR=\"Downloads\"", home),
+        None
+    );
+    assert_eq!(
+        parse_user_dir(b"XDG_DOWNLOAD_DIR=$HOME/Downloads", home),
+        None
+    );
+    assert_eq!(
+        parse_user_dir(b"XDG_DOWNLOAD_DIR=\"$HOME/broken\\\"", home),
+        None
+    );
 }
 
 #[test]

--- a/src/fs/restore.rs
+++ b/src/fs/restore.rs
@@ -17,43 +17,58 @@ use std::{
 ///   sibling `Trash/info/<name>.trashinfo` file must exist.  The original path
 ///   is read from that file and the item is moved back.
 ///
-/// - **macOS `~/.Trash`**: Finder records the original location internally
-///   when an item is trashed.  The `osascript` "put back" command asks Finder
-///   to use that metadata and move the item back — exactly what the Finder
-///   "Put Back" menu item does.
+/// - **macOS `~/.Trash`**: Elio reads the original location from its own
+///   restore-origins store, falling back to Finder's `.DS_Store` metadata,
+///   then moves the item back directly.
 ///
 /// The FreeDesktop path is tried first (it works even on macOS if the XDG
 /// layout happens to be present), then the macOS path, then an unsupported
 /// error for any other layout (e.g. Windows Recycle Bin).
 pub(crate) fn restore_trash_item(entry_path: &Path) -> anyhow::Result<()> {
-    // FreeDesktop trash layout: the entry lives inside a `files/` directory,
-    // and a sibling `info/` directory holds the `.trashinfo` metadata.
-    //
-    // Both conditions are required.  Checking only for `info/` two levels up
-    // is insufficient: on macOS, `~/.Trash/foo` would compute `~/info`, and
-    // if the user happens to have a `~/info` directory for any reason the
-    // function would take the FreeDesktop path and fail to find a `.trashinfo`
-    // instead of correctly falling through to the Finder backend.
-    let parent = entry_path.parent();
-    let in_files_dir = parent
-        .and_then(|p| p.file_name())
-        .is_some_and(|name| name == "files");
-    let info_dir = parent
-        .and_then(|p| p.parent())
-        .map(|trash_root| trash_root.join("info"));
-
-    if in_files_dir && info_dir.as_deref().is_some_and(|d| d.is_dir()) {
-        return restore_trash_item_freedesktop(entry_path, info_dir.unwrap());
+    if let Some(info_dir) = freedesktop_info_dir(entry_path) {
+        return restore_trash_item_freedesktop(entry_path, info_dir);
     }
 
-    // macOS: no .trashinfo metadata, but Finder tracks the original location
-    // internally.  Ask it to "put back" the item via osascript.
+    // macOS: no .trashinfo metadata; use Elio's restore-origins store or
+    // Finder's .DS_Store metadata.
     #[cfg(target_os = "macos")]
-    return restore_trash_item_macos(entry_path);
+    {
+        let file_name = restore_trash_item_macos(entry_path)?;
+        remove_restore_origins(&[&file_name]);
+        return Ok(());
+    }
 
     // Any other layout (e.g. Windows Recycle Bin) is not supported.
     #[cfg(not(target_os = "macos"))]
     anyhow::bail!("restore is not supported for this trash location")
+}
+
+/// Returns the FreeDesktop `info/` directory when `entry_path` is inside the
+/// sibling `files/` directory of a valid Trash layout.
+fn freedesktop_info_dir(entry_path: &Path) -> Option<PathBuf> {
+    // Requiring the immediate parent to be named `files` prevents a macOS
+    // ~/.Trash item from being misdetected merely because ~/info exists.
+    let parent = entry_path.parent()?;
+    if parent.file_name()? != "files" {
+        return None;
+    }
+    let info_dir = parent.parent()?.join("info");
+    info_dir.is_dir().then_some(info_dir)
+}
+
+/// Restores as usual but checks macOS restore-origin cleanup. A returned error
+/// means the filesystem restore completed and only metadata cleanup failed.
+#[cfg(target_os = "macos")]
+pub(crate) fn restore_trash_item_checked_metadata(
+    entry_path: &Path,
+) -> anyhow::Result<Option<anyhow::Error>> {
+    if let Some(info_dir) = freedesktop_info_dir(entry_path) {
+        restore_trash_item_freedesktop(entry_path, info_dir)?;
+        return Ok(None);
+    }
+
+    let file_name = restore_trash_item_macos(entry_path)?;
+    Ok(remove_restore_origins_checked(&[&file_name]).err())
 }
 
 /// FreeDesktop-specific restore: reads the `.trashinfo` sidecar and moves the
@@ -93,12 +108,9 @@ fn restore_trash_item_freedesktop(entry_path: &Path, info_dir: PathBuf) -> anyho
 // ---------------------------------------------------------------------------
 // macOS restore-origins store
 // ---------------------------------------------------------------------------
-// Elio trashes files via the `trash` crate, which calls
-// NSWorkspace.recycleURLs.  That API stores the original path in a private
-// system database that Finder reads for "Put Back" — it does NOT reliably
-// write ptbL/ptbN records to ~/.Trash/.DS_Store the way Finder's own drag-
-// to-trash action does.  Parsing .DS_Store therefore fails for any file Elio
-// trashed, even though Finder's own "Put Back" works fine for those files.
+// trash 5.2.6 defaults to asking Finder to move files to Trash through
+// `osascript`. Finder's Put Back metadata is private and `.DS_Store` ptbL/ptbN
+// records are not reliable enough for Elio's direct restore implementation.
 //
 // To work around this, whenever Elio trashes a file it immediately records
 // the original path in its own JSON store at
@@ -148,28 +160,43 @@ pub(crate) fn save_restore_origins(items: &[(String, PathBuf)]) {
 /// Best-effort: silently ignores any I/O error.
 #[cfg(target_os = "macos")]
 pub(crate) fn remove_restore_origins(trash_names: &[&str]) {
+    let _ = remove_restore_origins_checked(trash_names);
+}
+
+/// Checked variant used by the invoking-user helper. Missing metadata and
+/// names with no matching entry are successful no-ops; malformed metadata and
+/// real I/O failures are returned to the privileged parent.
+#[cfg(target_os = "macos")]
+pub(crate) fn remove_restore_origins_checked(trash_names: &[&str]) -> anyhow::Result<()> {
     let Some(path) = restore_origins_path() else {
-        return;
+        anyhow::bail!("cannot determine restore-origins path");
     };
-    let bytes = match fs::read(&path) {
+    remove_restore_origins_at_path_checked(&path, trash_names)
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn remove_restore_origins_at_path_checked(path: &Path, trash_names: &[&str]) -> anyhow::Result<()> {
+    let bytes = match fs::read(path) {
         Ok(b) => b,
-        Err(_) => return,
-    };
-    let mut map: std::collections::HashMap<String, String> = match serde_json::from_slice(&bytes) {
-        Ok(m) => m,
-        Err(_) => return,
-    };
-    if remove_from_origins_map(&mut map, trash_names) {
-        if let Ok(json) = serde_json::to_vec_pretty(&map) {
-            let _ = fs::write(&path, json);
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("cannot read {:?}", path));
         }
+    };
+    let mut map: std::collections::HashMap<String, String> =
+        serde_json::from_slice(&bytes).with_context(|| format!("cannot parse {:?}", path))?;
+    if remove_from_origins_map(&mut map, trash_names) {
+        let json = serde_json::to_vec_pretty(&map)
+            .with_context(|| format!("cannot serialize {:?}", path))?;
+        fs::write(path, json).with_context(|| format!("cannot write {:?}", path))?;
     }
+    Ok(())
 }
 
 /// Core map-mutation logic for [`remove_restore_origins`]: removes each name
 /// in `trash_names` from `map`, trying the exact key first then the
 /// collision-stripped base name.  Returns `true` if the map was modified.
-#[cfg(target_os = "macos")]
+#[cfg(any(test, target_os = "macos"))]
 fn remove_from_origins_map(
     map: &mut std::collections::HashMap<String, String>,
     trash_names: &[&str],
@@ -184,16 +211,16 @@ fn remove_from_origins_map(
         // "foo.txt") but appears in trash as "foo 2.txt".  Strip the suffix
         // and try again.
         let p = Path::new(name);
-        if let Some(stem) = p.file_stem().and_then(|s| s.to_str()) {
-            if let Some(base_stem) = strip_macos_collision_suffix(stem) {
-                let ext = p.extension().and_then(|e| e.to_str());
-                let base_name = match ext {
-                    Some(e) => format!("{base_stem}.{e}"),
-                    None => base_stem.to_owned(),
-                };
-                if map.remove(&base_name).is_some() {
-                    changed = true;
-                }
+        if let Some(stem) = p.file_stem().and_then(|s| s.to_str())
+            && let Some(base_stem) = strip_macos_collision_suffix(stem)
+        {
+            let ext = p.extension().and_then(|e| e.to_str());
+            let base_name = match ext {
+                Some(e) => format!("{base_stem}.{e}"),
+                None => base_stem.to_owned(),
+            };
+            if map.remove(&base_name).is_some() {
+                changed = true;
             }
         }
     }
@@ -227,7 +254,7 @@ fn load_restore_origin(trash_name: &str) -> Option<PathBuf> {
 
 /// Strips a macOS collision suffix (` 2`, ` 3`, …) from a file stem.
 /// Returns `Some(base)` if a suffix was stripped, `None` otherwise.
-#[cfg(target_os = "macos")]
+#[cfg(any(test, target_os = "macos"))]
 fn strip_macos_collision_suffix(stem: &str) -> Option<&str> {
     let (base, suffix) = stem.rsplit_once(' ')?;
     let n: u64 = suffix.parse().ok()?;
@@ -255,7 +282,7 @@ fn perform_restore(entry_path: &Path, original_path: &Path) -> anyhow::Result<()
 /// (populated whenever Elio trashes a file), then falls back to parsing
 /// `.DS_Store` for files trashed directly by Finder.
 #[cfg(target_os = "macos")]
-fn restore_trash_item_macos(entry_path: &Path) -> anyhow::Result<()> {
+fn restore_trash_item_macos(entry_path: &Path) -> anyhow::Result<String> {
     let file_name = entry_path
         .file_name()
         .and_then(|n| n.to_str())
@@ -272,7 +299,8 @@ fn restore_trash_item_macos(entry_path: &Path) -> anyhow::Result<()> {
 
     // ── Primary: our own restore-origins store ──────────────────────────────
     if let Some(original_path) = load_restore_origin(file_name) {
-        return perform_restore(entry_path, &original_path);
+        perform_restore(entry_path, &original_path)?;
+        return Ok(file_name.to_owned());
     }
 
     // ── Fallback: parse .DS_Store written by Finder ─────────────────────────
@@ -303,7 +331,7 @@ fn restore_trash_item_macos(entry_path: &Path) -> anyhow::Result<()> {
 
     perform_restore(entry_path, &original_path)?;
 
-    Ok(())
+    Ok(file_name.to_owned())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/fs/restore.rs
+++ b/src/fs/restore.rs
@@ -4,6 +4,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg(any(test, target_os = "macos"))]
+use std::io::Write;
+
+#[cfg(any(test, target_os = "macos"))]
+static RESTORE_ORIGINS_PROCESS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 // ---------------------------------------------------------------------------
 // Restore from trash
 // ---------------------------------------------------------------------------
@@ -115,7 +121,7 @@ fn restore_trash_item_freedesktop(entry_path: &Path, info_dir: PathBuf) -> anyho
 // To work around this, whenever Elio trashes a file it immediately records
 // the original path in its own JSON store at
 //   ~/Library/Application Support/elio/trash-origins.json
-// keyed by the expected filename in ~/.Trash.  Restore checks this store
+// keyed by the actual filename assigned in ~/.Trash.  Restore checks this store
 // first.  The DS_Store parser is kept as a fallback for files trashed
 // directly by Finder (which does write ptbL).
 
@@ -125,39 +131,70 @@ fn restore_origins_path() -> Option<PathBuf> {
     dirs::data_dir().map(|d| d.join("elio").join("trash-origins.json"))
 }
 
-/// Records `(trash_name, original_path)` pairs in the restore-origins store.
-/// `trash_name` is the filename as it will appear in `~/.Trash` (= the
-/// original filename when there is no collision).  Best-effort: silently
-/// ignored on any I/O error.
+/// Records `(actual_trash_name, original_path)` pairs in the restore-origins
+/// store. Finder may rename an item on collision, so callers must supply the
+/// name observed after the Trash operation. All failures are reported.
 #[cfg(target_os = "macos")]
-pub(crate) fn save_restore_origins(items: &[(String, PathBuf)]) {
+pub(crate) fn save_restore_origins_checked(
+    items: &[(String, PathBuf)],
+) -> anyhow::Result<Vec<PathBuf>> {
     let Some(path) = restore_origins_path() else {
-        return;
+        anyhow::bail!("cannot determine restore-origins path");
     };
-    let mut map: std::collections::HashMap<String, String> = fs::read(&path)
-        .ok()
-        .and_then(|b| serde_json::from_slice(&b).ok())
-        .unwrap_or_default();
+    save_restore_origins_at_path_checked(&path, items)
+}
 
+#[cfg(any(test, target_os = "macos"))]
+fn save_restore_origins_at_path_checked(
+    path: &Path,
+    items: &[(String, PathBuf)],
+) -> anyhow::Result<Vec<PathBuf>> {
+    save_restore_origins_at_path_with(path, items, write_restore_origins_atomically)
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn save_restore_origins_at_path_with(
+    path: &Path,
+    items: &[(String, PathBuf)],
+    persist: impl FnOnce(&Path, &[u8]) -> std::io::Result<()>,
+) -> anyhow::Result<Vec<PathBuf>> {
+    if items.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut additions = Vec::with_capacity(items.len());
+    let mut rejected = Vec::new();
     for (name, original) in items {
-        if let Some(s) = original.to_str() {
-            map.insert(name.clone(), s.to_owned());
+        if let Some(original) = original.to_str() {
+            additions.push((name.clone(), original.to_owned()));
+        } else {
+            rejected.push(original.clone());
         }
     }
 
-    if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
+    if additions.is_empty() {
+        return Ok(rejected);
     }
-    if let Ok(json) = serde_json::to_vec_pretty(&map) {
-        let _ = fs::write(&path, json);
-    }
+
+    with_restore_origins_transaction(path, || {
+        let mut map: std::collections::HashMap<String, String> = match fs::read(path) {
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .with_context(|| format!("cannot parse {:?}", path))?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Default::default(),
+            Err(error) => return Err(error).with_context(|| format!("cannot read {:?}", path)),
+        };
+        map.extend(additions);
+
+        let json = serde_json::to_vec_pretty(&map)
+            .with_context(|| format!("cannot serialize {:?}", path))?;
+        persist(path, &json).with_context(|| format!("cannot write {:?}", path))?;
+        Ok(rejected)
+    })
 }
 
-/// Removes entries for the given `trash_names` from the restore-origins store.
-/// For each name, first tries an exact key match, then strips any macOS
-/// collision suffix (` 2`, ` 3`, …) and tries again — so "foo 2.txt"
-/// correctly removes the "foo.txt" key that was saved at trash time.
-/// Best-effort: silently ignores any I/O error.
+/// Removes exact `trash_names` from the restore-origins store. Finder-assigned
+/// collision names are stored directly, so cleanup never infers another key.
+/// Best-effort for historical normal/direct-root call sites.
 #[cfg(target_os = "macos")]
 pub(crate) fn remove_restore_origins(trash_names: &[&str]) {
     let _ = remove_restore_origins_checked(trash_names);
@@ -176,26 +213,36 @@ pub(crate) fn remove_restore_origins_checked(trash_names: &[&str]) -> anyhow::Re
 
 #[cfg(any(test, target_os = "macos"))]
 fn remove_restore_origins_at_path_checked(path: &Path, trash_names: &[&str]) -> anyhow::Result<()> {
-    let bytes = match fs::read(path) {
-        Ok(b) => b,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => {
-            return Err(error).with_context(|| format!("cannot read {:?}", path));
-        }
-    };
-    let mut map: std::collections::HashMap<String, String> =
-        serde_json::from_slice(&bytes).with_context(|| format!("cannot parse {:?}", path))?;
-    if remove_from_origins_map(&mut map, trash_names) {
-        let json = serde_json::to_vec_pretty(&map)
-            .with_context(|| format!("cannot serialize {:?}", path))?;
-        fs::write(path, json).with_context(|| format!("cannot write {:?}", path))?;
-    }
-    Ok(())
+    remove_restore_origins_at_path_with(path, trash_names, write_restore_origins_atomically)
 }
 
-/// Core map-mutation logic for [`remove_restore_origins`]: removes each name
-/// in `trash_names` from `map`, trying the exact key first then the
-/// collision-stripped base name.  Returns `true` if the map was modified.
+#[cfg(any(test, target_os = "macos"))]
+fn remove_restore_origins_at_path_with(
+    path: &Path,
+    trash_names: &[&str],
+    persist: impl FnOnce(&Path, &[u8]) -> std::io::Result<()>,
+) -> anyhow::Result<()> {
+    with_restore_origins_transaction(path, || {
+        let bytes = match fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(error).with_context(|| format!("cannot read {:?}", path));
+            }
+        };
+        let mut map: std::collections::HashMap<String, String> =
+            serde_json::from_slice(&bytes).with_context(|| format!("cannot parse {:?}", path))?;
+        if remove_from_origins_map(&mut map, trash_names) {
+            let json = serde_json::to_vec_pretty(&map)
+                .with_context(|| format!("cannot serialize {:?}", path))?;
+            persist(path, &json).with_context(|| format!("cannot write {:?}", path))?;
+        }
+        Ok(())
+    })
+}
+
+/// Core map-mutation logic for [`remove_restore_origins`]. Returns `true` if
+/// at least one exact key was removed.
 #[cfg(any(test, target_os = "macos"))]
 fn remove_from_origins_map(
     map: &mut std::collections::HashMap<String, String>,
@@ -205,60 +252,144 @@ fn remove_from_origins_map(
     for &name in trash_names {
         if map.remove(name).is_some() {
             changed = true;
-            continue;
-        }
-        // Collision case: the file was stored under its original name (e.g.
-        // "foo.txt") but appears in trash as "foo 2.txt".  Strip the suffix
-        // and try again.
-        let p = Path::new(name);
-        if let Some(stem) = p.file_stem().and_then(|s| s.to_str())
-            && let Some(base_stem) = strip_macos_collision_suffix(stem)
-        {
-            let ext = p.extension().and_then(|e| e.to_str());
-            let base_name = match ext {
-                Some(e) => format!("{base_stem}.{e}"),
-                None => base_stem.to_owned(),
-            };
-            if map.remove(&base_name).is_some() {
-                changed = true;
-            }
         }
     }
     changed
 }
 
-/// Looks up the original path for a file currently named `trash_name`.
-/// Also tries stripping macOS collision suffixes (` 2`, ` 3`, …) from the
-/// stem, so files renamed on collision can still be matched.
+/// Looks up the original path for the exact filename currently in Trash.
 #[cfg(target_os = "macos")]
 fn load_restore_origin(trash_name: &str) -> Option<PathBuf> {
     let path = restore_origins_path()?;
-    let map: std::collections::HashMap<String, String> =
-        serde_json::from_slice(&fs::read(&path).ok()?).ok()?;
-
-    if let Some(orig) = map.get(trash_name) {
-        return Some(PathBuf::from(orig));
-    }
-
-    // Collision case: "foo 2.txt" → look up "foo.txt".
-    let p = Path::new(trash_name);
-    let stem = p.file_stem().and_then(|s| s.to_str())?;
-    let ext = p.extension().and_then(|e| e.to_str());
-    let base_stem = strip_macos_collision_suffix(stem)?;
-    let base_name = match ext {
-        Some(e) => format!("{base_stem}.{e}"),
-        None => base_stem.to_owned(),
-    };
-    map.get(&base_name).map(|s| PathBuf::from(s))
+    with_restore_origins_transaction(&path, || {
+        let map: std::collections::HashMap<String, String> =
+            serde_json::from_slice(&fs::read(&path)?)
+                .with_context(|| format!("cannot parse {:?}", path))?;
+        Ok(restore_origin_from_map(&map, trash_name))
+    })
+    .ok()
+    .flatten()
 }
 
-/// Strips a macOS collision suffix (` 2`, ` 3`, …) from a file stem.
-/// Returns `Some(base)` if a suffix was stripped, `None` otherwise.
 #[cfg(any(test, target_os = "macos"))]
-fn strip_macos_collision_suffix(stem: &str) -> Option<&str> {
-    let (base, suffix) = stem.rsplit_once(' ')?;
-    let n: u64 = suffix.parse().ok()?;
-    (n >= 2).then_some(base)
+fn restore_origin_from_map(
+    map: &std::collections::HashMap<String, String>,
+    trash_name: &str,
+) -> Option<PathBuf> {
+    map.get(trash_name).map(PathBuf::from)
+}
+
+#[cfg(any(test, target_os = "macos"))]
+/// Holds the complete metadata transaction under both a process-wide mutex
+/// and a stable sidecar file lock shared by independent Elio/helper processes.
+fn with_restore_origins_transaction<T>(
+    path: &Path,
+    operation: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    let _process_guard = RESTORE_ORIGINS_PROCESS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)
+        .with_context(|| format!("cannot create restore-origins directory {:?}", parent))?;
+
+    let _file_guard = RestoreOriginsFileLock::acquire(path)?;
+
+    operation()
+}
+
+#[cfg(any(test, target_os = "macos"))]
+struct RestoreOriginsFileLock(fs::File);
+
+#[cfg(any(test, target_os = "macos"))]
+impl RestoreOriginsFileLock {
+    fn acquire(path: &Path) -> anyhow::Result<Self> {
+        let lock_path = restore_origins_lock_path(path)?;
+        let mut options = fs::OpenOptions::new();
+        options.read(true).write(true).create(true).truncate(false);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options
+            .open(&lock_path)
+            .with_context(|| format!("cannot open restore-origins lock {:?}", lock_path))?;
+        file.lock()
+            .with_context(|| format!("cannot lock restore-origins store {:?}", lock_path))?;
+        Ok(Self(file))
+    }
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn restore_origins_lock_path(path: &Path) -> anyhow::Result<PathBuf> {
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("restore-origins path has no file name"))?;
+    let mut lock_name = file_name.to_os_string();
+    lock_name.push(".lock");
+    Ok(path.with_file_name(lock_name))
+}
+
+#[cfg(any(test, target_os = "macos"))]
+impl Drop for RestoreOriginsFileLock {
+    fn drop(&mut self) {
+        let _ = self.0.unlock();
+    }
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn write_restore_origins_atomically(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().unwrap_or_default().to_string_lossy();
+    let process_id = std::process::id();
+
+    for attempt in 0..100 {
+        let temp_path = parent.join(format!(".{file_name}.elio-tmp-{process_id}-{attempt}"));
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = match options.open(&temp_path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        };
+
+        let result = (|| {
+            file.write_all(contents)?;
+            file.sync_all()?;
+            drop(file);
+
+            #[cfg(windows)]
+            if path.exists() {
+                fs::remove_file(path)?;
+            }
+            fs::rename(&temp_path, path)?;
+
+            #[cfg(unix)]
+            fs::File::open(parent)?.sync_all()?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&temp_path);
+        }
+        return result;
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "could not create a temporary restore-origins file",
+    ))
 }
 
 /// Moves `entry_path` to `original_path`, creating parent directories as

--- a/src/fs/restore/tests.rs
+++ b/src/fs/restore/tests.rs
@@ -9,6 +9,13 @@ fn temp_path(label: &str) -> PathBuf {
     std::env::temp_dir().join(format!("elio-{label}-{unique}"))
 }
 
+fn cleanup_restore_origins_test_store(path: &Path) {
+    fs::remove_file(path).ok();
+    if let Ok(lock_path) = restore_origins_lock_path(path) {
+        fs::remove_file(lock_path).ok();
+    }
+}
+
 /// Builds a minimal FreeDesktop trash layout under `root`:
 ///   root/
 ///     files/<name>  ← the trashed item (a regular file)
@@ -203,28 +210,39 @@ fn remove_from_origins_map_removes_exact_match() {
 }
 
 #[test]
-fn remove_from_origins_map_handles_collision_suffix_with_extension() {
-    // "report.pdf" was stored as the key but macOS renamed it "report 2.pdf"
-    // in the trash due to a collision.
-    let mut map = std::collections::HashMap::from([(
-        "report.pdf".to_string(),
-        "/home/user/report.pdf".to_string(),
-    )]);
-    let changed = remove_from_origins_map(&mut map, &["report 2.pdf"]);
+fn remove_from_origins_map_removes_only_exact_timestamped_collision_key() {
+    let mut map = std::collections::HashMap::from([
+        (
+            "report.pdf".to_string(),
+            "/Users/paco/A/report.pdf".to_string(),
+        ),
+        (
+            "report 11.53.48.pdf".to_string(),
+            "/Users/paco/B/report.pdf".to_string(),
+        ),
+    ]);
+
+    let changed = remove_from_origins_map(&mut map, &["report 11.53.48.pdf"]);
+
     assert!(changed);
-    assert!(
-        map.is_empty(),
-        "collision-suffixed name should strip and remove base key"
+    assert_eq!(
+        map.get("report.pdf").map(String::as_str),
+        Some("/Users/paco/A/report.pdf")
     );
+    assert!(!map.contains_key("report 11.53.48.pdf"));
 }
 
 #[test]
-fn remove_from_origins_map_handles_collision_suffix_without_extension() {
-    let mut map =
-        std::collections::HashMap::from([("notes".to_string(), "/home/user/notes".to_string())]);
-    let changed = remove_from_origins_map(&mut map, &["notes 2"]);
-    assert!(changed);
-    assert!(map.is_empty());
+fn remove_from_origins_map_never_infers_a_base_name() {
+    let mut map = std::collections::HashMap::from([(
+        "report.pdf".to_string(),
+        "/Users/paco/A/report.pdf".to_string(),
+    )]);
+
+    let changed = remove_from_origins_map(&mut map, &["report 2.pdf"]);
+
+    assert!(!changed);
+    assert_eq!(map.len(), 1);
 }
 
 #[test]
@@ -263,9 +281,273 @@ fn remove_from_origins_map_no_op_on_empty_map() {
 }
 
 #[test]
+fn restore_origin_lookup_uses_exact_finder_assigned_names() {
+    let map = std::collections::HashMap::from([
+        ("foo.txt".to_string(), "/Users/paco/A/foo.txt".to_string()),
+        (
+            "foo 11.53.48.txt".to_string(),
+            "/Users/paco/B/foo.txt".to_string(),
+        ),
+    ]);
+
+    assert_eq!(
+        restore_origin_from_map(&map, "foo.txt"),
+        Some(PathBuf::from("/Users/paco/A/foo.txt"))
+    );
+    assert_eq!(
+        restore_origin_from_map(&map, "foo 11.53.48.txt"),
+        Some(PathBuf::from("/Users/paco/B/foo.txt"))
+    );
+    assert_eq!(restore_origin_from_map(&map, "foo 2.txt"), None);
+}
+
+#[test]
+fn checked_origin_save_preserves_distinct_collision_mappings_and_existing_entries() {
+    let path = temp_path("origins-save-collisions");
+    fs::write(&path, br#"{"existing.txt":"/Users/paco/existing.txt"}"#)
+        .expect("failed to write existing origins store");
+    let items = vec![
+        (
+            "foo.txt".to_string(),
+            PathBuf::from("/Users/paco/A/foo.txt"),
+        ),
+        (
+            "foo 11.53.48.txt".to_string(),
+            PathBuf::from("/Users/paco/B/foo.txt"),
+        ),
+    ];
+
+    let rejected = save_restore_origins_at_path_checked(&path, &items)
+        .expect("distinct Trash names should be persisted");
+    assert!(rejected.is_empty());
+
+    let map: std::collections::HashMap<String, String> =
+        serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    assert_eq!(
+        map.get("existing.txt").map(String::as_str),
+        Some("/Users/paco/existing.txt")
+    );
+    assert_eq!(
+        map.get("foo.txt").map(String::as_str),
+        Some("/Users/paco/A/foo.txt")
+    );
+    assert_eq!(
+        map.get("foo 11.53.48.txt").map(String::as_str),
+        Some("/Users/paco/B/foo.txt")
+    );
+    cleanup_restore_origins_test_store(&path);
+}
+
+#[cfg(unix)]
+#[test]
+fn checked_origin_save_keeps_valid_mappings_when_an_origin_is_not_utf8() {
+    use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+    let path = temp_path("origins-save-non-utf8");
+    fs::write(&path, br#"{"existing.txt":"/Users/paco/existing.txt"}"#)
+        .expect("failed to write existing origins store");
+    let invalid = PathBuf::from(OsString::from_vec(b"/Users/paco/bad-\xff.txt".to_vec()));
+    let items = vec![
+        (
+            "valid.txt".to_string(),
+            PathBuf::from("/Users/paco/valid.txt"),
+        ),
+        ("invalid.txt".to_string(), invalid.clone()),
+    ];
+
+    let rejected = save_restore_origins_at_path_checked(&path, &items)
+        .expect("representable mappings should still be saved");
+
+    assert_eq!(rejected, vec![invalid]);
+    let map: std::collections::HashMap<String, String> =
+        serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    assert_eq!(
+        map.get("existing.txt").map(String::as_str),
+        Some("/Users/paco/existing.txt")
+    );
+    assert_eq!(
+        map.get("valid.txt").map(String::as_str),
+        Some("/Users/paco/valid.txt")
+    );
+    assert!(!map.contains_key("invalid.txt"));
+    cleanup_restore_origins_test_store(&path);
+}
+
+#[test]
+fn concurrent_origin_saves_preserve_both_updates() {
+    use std::{
+        sync::mpsc::{self, RecvTimeoutError},
+        thread,
+        time::Duration,
+    };
+
+    let path = temp_path("origins-concurrent-save-save");
+    let (first_entered_tx, first_entered_rx) = mpsc::sync_channel(0);
+    let (release_first_tx, release_first_rx) = mpsc::sync_channel(0);
+    let first_path = path.clone();
+    let first = thread::spawn(move || {
+        let items = vec![("first.txt".to_string(), PathBuf::from("/A/first.txt"))];
+        save_restore_origins_at_path_with(&first_path, &items, |path, json| {
+            first_entered_tx.send(()).unwrap();
+            release_first_rx.recv().unwrap();
+            write_restore_origins_atomically(path, json)
+        })
+    });
+    first_entered_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("first save did not enter persistence");
+
+    let (second_entered_tx, second_entered_rx) = mpsc::sync_channel(0);
+    let second_path = path.clone();
+    let second = thread::spawn(move || {
+        let items = vec![("second.txt".to_string(), PathBuf::from("/B/second.txt"))];
+        save_restore_origins_at_path_with(&second_path, &items, |path, json| {
+            second_entered_tx.send(()).unwrap();
+            write_restore_origins_atomically(path, json)
+        })
+    });
+
+    assert!(matches!(
+        second_entered_rx.recv_timeout(Duration::from_millis(100)),
+        Err(RecvTimeoutError::Timeout)
+    ));
+    release_first_tx.send(()).unwrap();
+    assert!(first.join().unwrap().unwrap().is_empty());
+    second_entered_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("second save did not resume after the first transaction");
+    assert!(second.join().unwrap().unwrap().is_empty());
+
+    let map: std::collections::HashMap<String, String> =
+        serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    assert_eq!(
+        map.get("first.txt").map(String::as_str),
+        Some("/A/first.txt")
+    );
+    assert_eq!(
+        map.get("second.txt").map(String::as_str),
+        Some("/B/second.txt")
+    );
+    cleanup_restore_origins_test_store(&path);
+}
+
+#[test]
+fn concurrent_origin_save_and_remove_preserve_unrelated_updates() {
+    use std::{
+        sync::mpsc::{self, RecvTimeoutError},
+        thread,
+        time::Duration,
+    };
+
+    let path = temp_path("origins-concurrent-save-remove");
+    fs::write(
+        &path,
+        br#"{"remove.txt":"/old/remove.txt","keep.txt":"/old/keep.txt"}"#,
+    )
+    .unwrap();
+    let (save_entered_tx, save_entered_rx) = mpsc::sync_channel(0);
+    let (release_save_tx, release_save_rx) = mpsc::sync_channel(0);
+    let save_path = path.clone();
+    let save = thread::spawn(move || {
+        let items = vec![("new.txt".to_string(), PathBuf::from("/new/new.txt"))];
+        save_restore_origins_at_path_with(&save_path, &items, |path, json| {
+            save_entered_tx.send(()).unwrap();
+            release_save_rx.recv().unwrap();
+            write_restore_origins_atomically(path, json)
+        })
+    });
+    save_entered_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("save did not enter persistence");
+
+    let (remove_entered_tx, remove_entered_rx) = mpsc::sync_channel(0);
+    let remove_path = path.clone();
+    let remove = thread::spawn(move || {
+        remove_restore_origins_at_path_with(&remove_path, &["remove.txt"], |path, json| {
+            remove_entered_tx.send(()).unwrap();
+            write_restore_origins_atomically(path, json)
+        })
+    });
+
+    assert!(matches!(
+        remove_entered_rx.recv_timeout(Duration::from_millis(100)),
+        Err(RecvTimeoutError::Timeout)
+    ));
+    release_save_tx.send(()).unwrap();
+    assert!(save.join().unwrap().unwrap().is_empty());
+    remove_entered_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("remove did not resume after the save transaction");
+    remove.join().unwrap().unwrap();
+
+    let map: std::collections::HashMap<String, String> =
+        serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    assert!(!map.contains_key("remove.txt"));
+    assert_eq!(
+        map.get("keep.txt").map(String::as_str),
+        Some("/old/keep.txt")
+    );
+    assert_eq!(map.get("new.txt").map(String::as_str), Some("/new/new.txt"));
+    cleanup_restore_origins_test_store(&path);
+}
+
+#[test]
+fn restore_origins_sidecar_lock_serializes_independent_file_handles() {
+    use std::{
+        sync::mpsc::{self, RecvTimeoutError},
+        thread,
+        time::Duration,
+    };
+
+    let path = temp_path("origins-sidecar-lock");
+    let first = RestoreOriginsFileLock::acquire(&path).unwrap();
+    let (acquired_tx, acquired_rx) = mpsc::sync_channel(0);
+    let second_path = path.clone();
+    let second = thread::spawn(move || {
+        let _second = RestoreOriginsFileLock::acquire(&second_path).unwrap();
+        acquired_tx.send(()).unwrap();
+    });
+
+    assert!(matches!(
+        acquired_rx.recv_timeout(Duration::from_millis(100)),
+        Err(RecvTimeoutError::Timeout)
+    ));
+    drop(first);
+    acquired_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("second file handle did not acquire the released sidecar lock");
+    second.join().unwrap();
+    cleanup_restore_origins_test_store(&path);
+}
+
+#[test]
+fn checked_origin_save_reports_persistence_failure_without_touching_existing_mappings() {
+    let path = temp_path("origins-save-failure");
+    let existing = br#"{"existing.txt":"/Users/paco/existing.txt"}"#;
+    fs::write(&path, existing).expect("failed to write existing origins store");
+    let items = vec![(
+        "foo.txt".to_string(),
+        PathBuf::from("/Users/paco/A/foo.txt"),
+    )];
+
+    let error = save_restore_origins_at_path_with(&path, &items, |_, _| {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "store is read-only",
+        ))
+    })
+    .unwrap_err();
+
+    assert!(error.to_string().contains("cannot write"));
+    assert_eq!(fs::read(&path).unwrap(), existing);
+    cleanup_restore_origins_test_store(&path);
+}
+
+#[test]
 fn checked_origin_removal_accepts_missing_store() {
     let path = temp_path("origins-missing");
     assert!(remove_restore_origins_at_path_checked(&path, &["foo.txt"]).is_ok());
+    cleanup_restore_origins_test_store(&path);
 }
 
 #[test]
@@ -278,7 +560,7 @@ fn checked_origin_removal_accepts_missing_key_without_rewriting() {
         .expect("missing key should be a successful no-op");
 
     assert_eq!(fs::read(&path).unwrap(), contents);
-    fs::remove_file(path).ok();
+    cleanup_restore_origins_test_store(&path);
 }
 
 #[test]
@@ -300,7 +582,7 @@ fn checked_origin_removal_persists_matching_mutation() {
         map.get("notes.txt").map(String::as_str),
         Some("/Users/paco/notes.txt")
     );
-    fs::remove_file(path).ok();
+    cleanup_restore_origins_test_store(&path);
 }
 
 #[test]
@@ -312,7 +594,7 @@ fn checked_origin_removal_rejects_malformed_store() {
 
     assert!(error.to_string().contains("cannot parse"));
     assert_eq!(fs::read(&path).unwrap(), b"{");
-    fs::remove_file(path).ok();
+    cleanup_restore_origins_test_store(&path);
 }
 
 #[cfg(unix)]
@@ -324,7 +606,8 @@ fn checked_origin_removal_reports_read_failure() {
     let error = remove_restore_origins_at_path_checked(&path, &["report.pdf"]).unwrap_err();
 
     assert!(error.to_string().contains("cannot read"));
-    fs::remove_dir(path).ok();
+    fs::remove_dir(&path).ok();
+    cleanup_restore_origins_test_store(&path);
 }
 
 #[cfg(unix)]
@@ -335,15 +618,19 @@ fn checked_origin_removal_reports_write_failure() {
     if unsafe { libc::geteuid() } == 0 {
         return;
     }
-    let path = temp_path("origins-write-error");
+    let root = temp_path("origins-write-error");
+    fs::create_dir(&root).expect("failed to create origins directory");
+    let path = root.join("trash-origins.json");
     fs::write(&path, br#"{"report.pdf":"/Users/paco/report.pdf"}"#)
         .expect("failed to write origins store");
-    fs::set_permissions(&path, fs::Permissions::from_mode(0o400))
-        .expect("failed to make origins store read-only");
+    fs::write(restore_origins_lock_path(&path).unwrap(), b"")
+        .expect("failed to create restore-origins lock");
+    fs::set_permissions(&root, fs::Permissions::from_mode(0o500))
+        .expect("failed to make origins directory read-only");
 
     let error = remove_restore_origins_at_path_checked(&path, &["report.pdf"]).unwrap_err();
 
     assert!(error.to_string().contains("cannot write"));
-    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).ok();
-    fs::remove_file(path).ok();
+    fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).ok();
+    fs::remove_dir_all(root).ok();
 }

--- a/src/fs/restore/tests.rs
+++ b/src/fs/restore/tests.rs
@@ -182,7 +182,6 @@ fn decode_utf16be_empty_slice_gives_empty_string() {
 // ── remove_from_origins_map ───────────────────────────────────────────────
 
 #[test]
-#[cfg(target_os = "macos")]
 fn remove_from_origins_map_removes_exact_match() {
     let mut map = std::collections::HashMap::from([
         (
@@ -204,7 +203,6 @@ fn remove_from_origins_map_removes_exact_match() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn remove_from_origins_map_handles_collision_suffix_with_extension() {
     // "report.pdf" was stored as the key but macOS renamed it "report 2.pdf"
     // in the trash due to a collision.
@@ -221,7 +219,6 @@ fn remove_from_origins_map_handles_collision_suffix_with_extension() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn remove_from_origins_map_handles_collision_suffix_without_extension() {
     let mut map =
         std::collections::HashMap::from([("notes".to_string(), "/home/user/notes".to_string())]);
@@ -231,7 +228,6 @@ fn remove_from_origins_map_handles_collision_suffix_without_extension() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn remove_from_origins_map_returns_false_when_key_not_found() {
     let mut map = std::collections::HashMap::from([(
         "other.txt".to_string(),
@@ -246,7 +242,6 @@ fn remove_from_origins_map_returns_false_when_key_not_found() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn remove_from_origins_map_removes_multiple_names() {
     let mut map = std::collections::HashMap::from([
         ("a.txt".to_string(), "/home/user/a.txt".to_string()),
@@ -261,9 +256,94 @@ fn remove_from_origins_map_removes_multiple_names() {
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn remove_from_origins_map_no_op_on_empty_map() {
     let mut map = std::collections::HashMap::new();
     let changed = remove_from_origins_map(&mut map, &["foo.txt"]);
     assert!(!changed);
+}
+
+#[test]
+fn checked_origin_removal_accepts_missing_store() {
+    let path = temp_path("origins-missing");
+    assert!(remove_restore_origins_at_path_checked(&path, &["foo.txt"]).is_ok());
+}
+
+#[test]
+fn checked_origin_removal_accepts_missing_key_without_rewriting() {
+    let path = temp_path("origins-missing-key");
+    let contents = br#"{"other.txt":"/Users/paco/other.txt"}"#;
+    fs::write(&path, contents).expect("failed to write origins store");
+
+    remove_restore_origins_at_path_checked(&path, &["foo.txt"])
+        .expect("missing key should be a successful no-op");
+
+    assert_eq!(fs::read(&path).unwrap(), contents);
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn checked_origin_removal_persists_matching_mutation() {
+    let path = temp_path("origins-persist");
+    fs::write(
+        &path,
+        br#"{"report.pdf":"/Users/paco/report.pdf","notes.txt":"/Users/paco/notes.txt"}"#,
+    )
+    .expect("failed to write origins store");
+
+    remove_restore_origins_at_path_checked(&path, &["report.pdf"])
+        .expect("matching key should be removed");
+
+    let map: std::collections::HashMap<String, String> =
+        serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    assert!(!map.contains_key("report.pdf"));
+    assert_eq!(
+        map.get("notes.txt").map(String::as_str),
+        Some("/Users/paco/notes.txt")
+    );
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn checked_origin_removal_rejects_malformed_store() {
+    let path = temp_path("origins-malformed");
+    fs::write(&path, b"{").expect("failed to write malformed origins store");
+
+    let error = remove_restore_origins_at_path_checked(&path, &["report.pdf"]).unwrap_err();
+
+    assert!(error.to_string().contains("cannot parse"));
+    assert_eq!(fs::read(&path).unwrap(), b"{");
+    fs::remove_file(path).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn checked_origin_removal_reports_read_failure() {
+    let path = temp_path("origins-read-error");
+    fs::create_dir(&path).expect("failed to create origins directory");
+
+    let error = remove_restore_origins_at_path_checked(&path, &["report.pdf"]).unwrap_err();
+
+    assert!(error.to_string().contains("cannot read"));
+    fs::remove_dir(path).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn checked_origin_removal_reports_write_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+    let path = temp_path("origins-write-error");
+    fs::write(&path, br#"{"report.pdf":"/Users/paco/report.pdf"}"#)
+        .expect("failed to write origins store");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o400))
+        .expect("failed to make origins store read-only");
+
+    let error = remove_restore_origins_at_path_checked(&path, &["report.pdf"]).unwrap_err();
+
+    assert!(error.to_string().contains("cannot write"));
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).ok();
+    fs::remove_file(path).ok();
 }

--- a/src/invoking_user_command.rs
+++ b/src/invoking_user_command.rs
@@ -9,6 +9,35 @@ use std::{
     process::Command,
 };
 
+/// Applies the identity policy for user-facing external applications.
+///
+/// Normal launches are left untouched. Elevated launches run as the invoking
+/// user, use `cwd` when the action has an explicit directory, and otherwise
+/// start from that user's home. Unresolved elevated identity fails closed.
+#[cfg(unix)]
+pub(crate) fn prepare_external(command: &mut Command, cwd: Option<&Path>) -> io::Result<()> {
+    prepare_external_for_context(command, crate::config::invoking_user_context(), cwd)
+}
+
+#[cfg(unix)]
+fn prepare_external_for_context(
+    command: &mut Command,
+    context: crate::config::InvocationContext,
+    cwd: Option<&Path>,
+) -> io::Result<()> {
+    match context {
+        crate::config::InvocationContext::Normal => Ok(()),
+        crate::config::InvocationContext::Elevated(user) => {
+            let cwd = cwd.unwrap_or(&user.home);
+            prepare(command, &user, Some(cwd))
+        }
+        crate::config::InvocationContext::ElevatedUnresolved => Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "could not resolve invoking user",
+        )),
+    }
+}
+
 #[cfg(unix)]
 pub(crate) fn prepare(
     command: &mut Command,
@@ -62,26 +91,59 @@ fn apply_user_environment(command: &mut Command, user: &InvokingUser) {
         .env_remove("SUDO_GID")
         .env_remove("SUDO_UID")
         .env_remove("SUDO_USER")
-        .env_remove("DOAS_USER")
-        .env_remove("XDG_CACHE_HOME")
-        .env_remove("XDG_CONFIG_HOME")
-        .env_remove("XDG_DATA_HOME");
+        .env_remove("DOAS_USER");
 
+    for name in crate::config::SESSION_ENVIRONMENT_KEYS {
+        command.env_remove(name);
+    }
+    for (name, value) in &user.session_environment {
+        if !matches!(
+            name.to_str(),
+            Some(
+                "XAUTHORITY"
+                    | "XDG_CACHE_HOME"
+                    | "XDG_CONFIG_HOME"
+                    | "XDG_DATA_HOME"
+                    | "XDG_RUNTIME_DIR"
+            )
+        ) {
+            command.env(name, value);
+        }
+    }
+
+    if let Some(path) = &user.xdg_config_home {
+        command.env("XDG_CONFIG_HOME", path);
+    }
     if let Some(path) = &user.xdg_data_home {
         command.env("XDG_DATA_HOME", path);
     }
-    preserve_owned_absolute_env(command, "XDG_CONFIG_HOME", user.uid);
-    preserve_owned_absolute_env(command, "XDG_CACHE_HOME", user.uid);
-    if !valid_runtime_dir(std::env::var_os("XDG_RUNTIME_DIR").as_deref(), user.uid) {
-        command.env_remove("XDG_RUNTIME_DIR");
+    set_owned_absolute_env(command, user, "XDG_CACHE_HOME");
+    set_owned_path_env(command, user, "XAUTHORITY");
+    if let Some(path) = crate::config::user_environment_value(user, "XDG_RUNTIME_DIR")
+        && valid_runtime_dir(Some(path), user.uid)
+    {
+        command.env("XDG_RUNTIME_DIR", path);
     }
 }
 
 #[cfg(unix)]
-fn preserve_owned_absolute_env(command: &mut Command, name: &str, uid: libc::uid_t) {
-    if let Some(path) = std::env::var_os(name)
+fn set_owned_absolute_env(command: &mut Command, user: &InvokingUser, name: &str) {
+    if let Some(path) = crate::config::user_environment_value(user, name)
         .map(PathBuf::from)
-        .filter(|path| valid_owned_absolute_path(path, uid))
+        .filter(|path| valid_owned_absolute_path(path, user.uid))
+    {
+        command.env(name, path);
+    }
+}
+
+#[cfg(unix)]
+fn set_owned_path_env(command: &mut Command, user: &InvokingUser, name: &str) {
+    use std::os::unix::fs::MetadataExt;
+
+    if let Some(path) = crate::config::user_environment_value(user, name)
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .filter(|path| std::fs::metadata(path).is_ok_and(|metadata| metadata.uid() == user.uid))
     {
         command.env(name, path);
     }
@@ -184,6 +246,23 @@ mod tests {
             home: PathBuf::from("/home/paco"),
             shell: OsString::from("/bin/fish"),
             groups: vec![1000],
+            session_environment: vec![
+                (
+                    OsString::from("DBUS_SESSION_BUS_ADDRESS"),
+                    OsString::from("unix:path=/run/user/1000/bus"),
+                ),
+                (OsString::from("DISPLAY"), OsString::from(":1")),
+                (OsString::from("EDITOR"), OsString::from("nvim")),
+                (
+                    OsString::from("PATH"),
+                    OsString::from("/home/paco/.local/bin:/usr/bin"),
+                ),
+                (
+                    OsString::from("WAYLAND_DISPLAY"),
+                    OsString::from("wayland-1"),
+                ),
+            ],
+            xdg_config_home: Some(PathBuf::from("/home/paco/.config")),
             xdg_data_home: Some(PathBuf::from("/home/paco/.local/share")),
         }
     }
@@ -229,6 +308,38 @@ mod tests {
             command_env(&command, "XDG_DATA_HOME"),
             Some(Some(OsString::from("/home/paco/.local/share")))
         );
+        assert_eq!(
+            command_env(&command, "XDG_CONFIG_HOME"),
+            Some(Some(OsString::from("/home/paco/.config")))
+        );
+        assert_eq!(
+            command_env(&command, "DISPLAY"),
+            Some(Some(OsString::from(":1")))
+        );
+        assert_eq!(
+            command_env(&command, "WAYLAND_DISPLAY"),
+            Some(Some(OsString::from("wayland-1")))
+        );
+        assert_eq!(
+            command_env(&command, "EDITOR"),
+            Some(Some(OsString::from("nvim")))
+        );
+    }
+
+    #[test]
+    fn absent_invoking_user_session_values_remove_root_values() {
+        let mut user = test_user();
+        user.session_environment.clear();
+        let mut command = Command::new("true");
+        apply_user_environment(&mut command, &user);
+
+        assert_eq!(command_env(&command, "DISPLAY"), Some(None));
+        assert_eq!(command_env(&command, "WAYLAND_DISPLAY"), Some(None));
+        assert_eq!(
+            command_env(&command, "DBUS_SESSION_BUS_ADDRESS"),
+            Some(None)
+        );
+        assert_eq!(command_env(&command, "EDITOR"), Some(None));
     }
 
     #[test]
@@ -256,6 +367,70 @@ mod tests {
             command_env(&command, "PWD"),
             Some(Some(OsString::from("/home/paco/Documents")))
         );
+    }
+
+    #[test]
+    fn normal_external_command_is_left_unchanged() {
+        let mut command = Command::new("true");
+        prepare_external_for_context(
+            &mut command,
+            crate::config::InvocationContext::Normal,
+            Some(Path::new("/ignored")),
+        )
+        .unwrap();
+
+        assert_eq!(command.get_current_dir(), None);
+        assert_eq!(command_env(&command, "HOME"), None);
+    }
+
+    #[test]
+    fn elevated_detached_command_uses_invoking_user_home() {
+        let mut command = Command::new("true");
+        prepare_external_for_context(
+            &mut command,
+            crate::config::InvocationContext::Elevated(test_user()),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            command_env(&command, "PWD"),
+            Some(Some(OsString::from("/home/paco")))
+        );
+        assert_eq!(
+            command_env(&command, "HOME"),
+            Some(Some(OsString::from("/home/paco")))
+        );
+    }
+
+    #[test]
+    fn elevated_external_command_uses_requested_working_directory() {
+        let mut command = Command::new("true");
+        prepare_external_for_context(
+            &mut command,
+            crate::config::InvocationContext::Elevated(test_user()),
+            Some(Path::new("/home/paco/Documents")),
+        )
+        .unwrap();
+
+        assert_eq!(
+            command_env(&command, "PWD"),
+            Some(Some(OsString::from("/home/paco/Documents")))
+        );
+    }
+
+    #[test]
+    fn unresolved_elevated_external_command_fails_closed() {
+        let mut command = Command::new("true");
+        let error = prepare_external_for_context(
+            &mut command,
+            crate::config::InvocationContext::ElevatedUnresolved,
+            None,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(error.to_string(), "could not resolve invoking user");
     }
 
     #[test]

--- a/src/invoking_user_command.rs
+++ b/src/invoking_user_command.rs
@@ -26,7 +26,8 @@ fn prepare_external_for_context(
     cwd: Option<&Path>,
 ) -> io::Result<()> {
     match context {
-        crate::config::InvocationContext::Normal => Ok(()),
+        crate::config::InvocationContext::Normal
+        | crate::config::InvocationContext::RootSession => Ok(()),
         crate::config::InvocationContext::Elevated(user) => {
             let cwd = cwd.unwrap_or(&user.home);
             prepare(command, &user, Some(cwd))

--- a/src/invoking_user_command.rs
+++ b/src/invoking_user_command.rs
@@ -22,7 +22,7 @@ pub(crate) fn prepare_external(command: &mut Command, cwd: Option<&Path>) -> io:
 #[cfg(unix)]
 fn prepare_external_for_context(
     command: &mut Command,
-    context: crate::config::InvocationContext,
+    context: &crate::config::InvocationContext,
     cwd: Option<&Path>,
 ) -> io::Result<()> {
     match context {
@@ -30,7 +30,7 @@ fn prepare_external_for_context(
         | crate::config::InvocationContext::RootSession => Ok(()),
         crate::config::InvocationContext::Elevated(user) => {
             let cwd = cwd.unwrap_or(&user.home);
-            prepare(command, &user, Some(cwd))
+            prepare(command, user, Some(cwd))
         }
         crate::config::InvocationContext::ElevatedUnresolved => Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
@@ -375,7 +375,7 @@ mod tests {
         let mut command = Command::new("true");
         prepare_external_for_context(
             &mut command,
-            crate::config::InvocationContext::Normal,
+            &crate::config::InvocationContext::Normal,
             Some(Path::new("/ignored")),
         )
         .unwrap();
@@ -389,7 +389,7 @@ mod tests {
         let mut command = Command::new("true");
         prepare_external_for_context(
             &mut command,
-            crate::config::InvocationContext::Elevated(test_user()),
+            &crate::config::InvocationContext::Elevated(test_user()),
             None,
         )
         .unwrap();
@@ -409,7 +409,7 @@ mod tests {
         let mut command = Command::new("true");
         prepare_external_for_context(
             &mut command,
-            crate::config::InvocationContext::Elevated(test_user()),
+            &crate::config::InvocationContext::Elevated(test_user()),
             Some(Path::new("/home/paco/Documents")),
         )
         .unwrap();
@@ -425,7 +425,7 @@ mod tests {
         let mut command = Command::new("true");
         let error = prepare_external_for_context(
             &mut command,
-            crate::config::InvocationContext::ElevatedUnresolved,
+            &crate::config::InvocationContext::ElevatedUnresolved,
             None,
         )
         .unwrap_err();

--- a/src/invoking_user_command.rs
+++ b/src/invoking_user_command.rs
@@ -1,0 +1,289 @@
+#[cfg(unix)]
+use crate::config::InvokingUser;
+#[cfg(unix)]
+use std::{
+    ffi::{CString, OsStr},
+    io,
+    os::unix::{ffi::OsStrExt, process::CommandExt},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[cfg(unix)]
+pub(crate) fn prepare(
+    command: &mut Command,
+    user: &InvokingUser,
+    cwd: Option<&Path>,
+) -> io::Result<()> {
+    let cwd = cwd
+        .map(|path| CString::new(path.as_os_str().as_bytes()))
+        .transpose()
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "working directory contains NUL",
+            )
+        })?;
+
+    apply_user_environment(command, user);
+    if let Some(path) = cwd.as_ref() {
+        command.env("PWD", OsStr::from_bytes(path.as_bytes()));
+    }
+
+    let uid = user.uid;
+    let gid = user.gid;
+    let groups = user.groups.clone();
+    unsafe {
+        command.pre_exec(move || {
+            drop_privileges(uid, gid, &groups)?;
+            match &cwd {
+                Some(cwd) if libc::chdir(cwd.as_ptr()) != 0 => {
+                    return Err(io::Error::last_os_error());
+                }
+                _ => {}
+            }
+            Ok(())
+        });
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn apply_user_environment(command: &mut Command, user: &InvokingUser) {
+    command
+        .env("HOME", &user.home)
+        .env("USER", &user.name)
+        .env("USERNAME", &user.name)
+        .env("LOGNAME", &user.name)
+        .env("SHELL", &user.shell)
+        .env_remove("MAIL")
+        .env_remove("OLDPWD")
+        .env_remove("SUDO_COMMAND")
+        .env_remove("SUDO_GID")
+        .env_remove("SUDO_UID")
+        .env_remove("SUDO_USER")
+        .env_remove("DOAS_USER")
+        .env_remove("XDG_CACHE_HOME")
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("XDG_DATA_HOME");
+
+    if let Some(path) = &user.xdg_data_home {
+        command.env("XDG_DATA_HOME", path);
+    }
+    preserve_owned_absolute_env(command, "XDG_CONFIG_HOME", user.uid);
+    preserve_owned_absolute_env(command, "XDG_CACHE_HOME", user.uid);
+    if !valid_runtime_dir(std::env::var_os("XDG_RUNTIME_DIR").as_deref(), user.uid) {
+        command.env_remove("XDG_RUNTIME_DIR");
+    }
+}
+
+#[cfg(unix)]
+fn preserve_owned_absolute_env(command: &mut Command, name: &str, uid: libc::uid_t) {
+    if let Some(path) = std::env::var_os(name)
+        .map(PathBuf::from)
+        .filter(|path| valid_owned_absolute_path(path, uid))
+    {
+        command.env(name, path);
+    }
+}
+
+#[cfg(unix)]
+fn valid_owned_absolute_path(path: &Path, uid: libc::uid_t) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    path.is_absolute()
+        && path
+            .ancestors()
+            .find_map(|ancestor| match std::fs::metadata(ancestor) {
+                Ok(metadata) => Some(metadata.is_dir() && metadata.uid() == uid),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+                Err(_) => Some(false),
+            })
+            == Some(true)
+}
+
+#[cfg(unix)]
+fn valid_runtime_dir(path: Option<&OsStr>, uid: libc::uid_t) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let Some(path) = path.map(Path::new).filter(|path| path.is_absolute()) else {
+        return false;
+    };
+    std::fs::metadata(path).is_ok_and(|metadata| metadata.is_dir() && metadata.uid() == uid)
+}
+
+#[cfg(unix)]
+fn drop_privileges(uid: libc::uid_t, gid: libc::gid_t, groups: &[libc::gid_t]) -> io::Result<()> {
+    if unsafe { set_supplementary_groups(groups) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if unsafe { libc::setgid(gid) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if unsafe { libc::setuid(uid) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if !credentials_match(uid, gid) {
+        return Err(io::Error::from_raw_os_error(libc::EPERM));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+unsafe fn set_supplementary_groups(groups: &[libc::gid_t]) -> libc::c_int {
+    unsafe { libc::setgroups(groups.len(), groups.as_ptr()) }
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+unsafe fn set_supplementary_groups(groups: &[libc::gid_t]) -> libc::c_int {
+    let Ok(count) = libc::c_int::try_from(groups.len()) else {
+        return -1;
+    };
+    unsafe { libc::setgroups(count, groups.as_ptr()) }
+}
+
+#[cfg(unix)]
+fn credentials_match(uid: libc::uid_t, gid: libc::gid_t) -> bool {
+    if unsafe { libc::getuid() } != uid
+        || unsafe { libc::geteuid() } != uid
+        || unsafe { libc::getgid() } != gid
+        || unsafe { libc::getegid() } != gid
+    {
+        return false;
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    {
+        let (mut real_uid, mut effective_uid, mut saved_uid) = (0, 0, 0);
+        let (mut real_gid, mut effective_gid, mut saved_gid) = (0, 0, 0);
+        if unsafe { libc::getresuid(&mut real_uid, &mut effective_uid, &mut saved_uid) } != 0
+            || unsafe { libc::getresgid(&mut real_gid, &mut effective_gid, &mut saved_gid) } != 0
+        {
+            return false;
+        }
+        if (real_uid, effective_uid, saved_uid) != (uid, uid, uid)
+            || (real_gid, effective_gid, saved_gid) != (gid, gid, gid)
+        {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    fn test_user() -> InvokingUser {
+        InvokingUser {
+            uid: 1000,
+            gid: 1000,
+            name: OsString::from("paco"),
+            home: PathBuf::from("/home/paco"),
+            shell: OsString::from("/bin/fish"),
+            groups: vec![1000],
+            xdg_data_home: Some(PathBuf::from("/home/paco/.local/share")),
+        }
+    }
+
+    fn command_env(command: &Command, name: &str) -> Option<Option<OsString>> {
+        command
+            .get_envs()
+            .find(|(key, _)| *key == OsStr::new(name))
+            .map(|(_, value)| value.map(OsStr::to_os_string))
+    }
+
+    #[test]
+    fn user_environment_replaces_identity_and_removes_elevation_metadata() {
+        let mut command = Command::new("true");
+        apply_user_environment(&mut command, &test_user());
+
+        assert_eq!(
+            command_env(&command, "HOME"),
+            Some(Some(OsString::from("/home/paco")))
+        );
+        assert_eq!(
+            command_env(&command, "USER"),
+            Some(Some(OsString::from("paco")))
+        );
+        assert_eq!(
+            command_env(&command, "USERNAME"),
+            Some(Some(OsString::from("paco")))
+        );
+        assert_eq!(
+            command_env(&command, "LOGNAME"),
+            Some(Some(OsString::from("paco")))
+        );
+        assert_eq!(
+            command_env(&command, "SHELL"),
+            Some(Some(OsString::from("/bin/fish")))
+        );
+        assert_eq!(command_env(&command, "SUDO_UID"), Some(None));
+        assert_eq!(command_env(&command, "SUDO_USER"), Some(None));
+        assert_eq!(command_env(&command, "DOAS_USER"), Some(None));
+        assert_eq!(command_env(&command, "MAIL"), Some(None));
+        assert_eq!(command_env(&command, "OLDPWD"), Some(None));
+        assert_eq!(
+            command_env(&command, "XDG_DATA_HOME"),
+            Some(Some(OsString::from("/home/paco/.local/share")))
+        );
+    }
+
+    #[test]
+    fn prepare_rejects_nul_in_working_directory_before_spawn() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let mut command = Command::new("true");
+        let path = Path::new(OsStr::from_bytes(b"/tmp/a\0b"));
+        let error = prepare(&mut command, &test_user(), Some(path)).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn prepare_sets_pwd_to_requested_working_directory() {
+        let mut command = Command::new("true");
+        prepare(
+            &mut command,
+            &test_user(),
+            Some(Path::new("/home/paco/Documents")),
+        )
+        .unwrap();
+
+        assert_eq!(
+            command_env(&command, "PWD"),
+            Some(Some(OsString::from("/home/paco/Documents")))
+        );
+    }
+
+    #[test]
+    fn runtime_dir_must_be_absolute_existing_and_user_owned() {
+        assert!(!valid_runtime_dir(Some(OsStr::new("relative")), 1000));
+        assert!(!valid_runtime_dir(Some(OsStr::new("/missing")), 1000));
+        let temp = std::env::temp_dir().join(format!(
+            "elio-runtime-dir-test-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed")
+        ));
+        std::fs::create_dir_all(&temp).unwrap();
+        let uid = unsafe { libc::geteuid() };
+        assert!(valid_runtime_dir(Some(temp.as_os_str()), uid));
+        std::fs::remove_dir(&temp).unwrap();
+    }
+
+    #[test]
+    fn owned_absolute_path_accepts_missing_leaf_under_user_directory() {
+        let temp = std::env::temp_dir().join(format!(
+            "elio-user-env-test-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed")
+        ));
+        std::fs::create_dir_all(&temp).unwrap();
+        let uid = unsafe { libc::geteuid() };
+        assert!(valid_owned_absolute_path(&temp.join("missing"), uid));
+        assert!(!valid_owned_absolute_path(Path::new("relative"), uid));
+        std::fs::remove_dir(&temp).unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod config;
 mod core;
 mod file_info;
 mod fs;
+mod invoking_user_command;
 mod path_display;
 mod preview;
 mod runtime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod preview;
 mod runtime;
 mod shell;
 mod ui;
+mod user_fs_helper;
 mod zoxide;
 
 use anyhow::Result;
@@ -40,6 +41,11 @@ pub fn run_at(cwd: PathBuf) -> Result<()> {
 
 pub fn run_with_options(options: RunOptions) -> Result<()> {
     runtime::run_with_startup_state(options, None, false, None).map(|_| ())
+}
+
+#[doc(hidden)]
+pub fn run_user_fs_helper() -> Result<()> {
+    user_fs_helper::run()
 }
 
 #[doc(hidden)]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -138,11 +138,24 @@ fn run_open_command_in_terminal(
 }
 
 #[cfg(unix)]
+struct EditorTempCleanup(PathBuf);
+
+#[cfg(unix)]
+impl Drop for EditorTempCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+#[cfg(unix)]
 fn run_blocking_in_terminal_result(
     program: &str,
     args: &[String],
 ) -> std::io::Result<std::process::ExitStatus> {
-    Command::new(program).args(args).status()
+    let mut command = Command::new(program);
+    command.args(args);
+    crate::invoking_user_command::prepare_external(&mut command, None)?;
+    command.status()
 }
 
 fn refresh_after_shell(app: &mut App, cwd: &Path) {
@@ -489,6 +502,7 @@ fn run_app(
                         args,
                         session,
                     } => {
+                        let _temp_cleanup = EditorTempCleanup(session.temp_path.clone());
                         pause_runtime_input(&input_reader, true);
                         suspend_terminal(terminal, drainer, true, kitty_dnd)?;
                         let result = run_blocking_in_terminal_result(&program, &args);
@@ -1008,7 +1022,7 @@ mod tests {
         event_poll_interval,
     };
     #[cfg(unix)]
-    use super::{drag_icon_label_with, unsupported_drop_scheme_status};
+    use super::{EditorTempCleanup, drag_icon_label_with, unsupported_drop_scheme_status};
     use crossterm::event::Event;
     use std::time::Duration;
     #[cfg(unix)]
@@ -1073,6 +1087,24 @@ mod tests {
         assert!(!event_implies_terminal_focus(&Event::FocusLost));
         assert!(!event_implies_terminal_focus(&Event::FocusGained));
         assert!(!event_implies_terminal_focus(&Event::Resize(80, 24)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn editor_temp_cleanup_removes_document_on_drop() {
+        let path = std::env::temp_dir().join(format!(
+            "elio-editor-cleanup-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        fs::write(&path, "alpha.txt\n").expect("failed to create editor temp document");
+        {
+            let _cleanup = EditorTempCleanup(path.clone());
+        }
+        assert!(!path.exists());
     }
 
     #[cfg(unix)]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -123,8 +123,18 @@ pub(crate) fn run_with_startup_state(
     }
 }
 
-fn run_blocking_in_terminal(program: &str, args: &[String]) {
-    let _ = Command::new(program).args(args).status();
+fn run_open_command_in_terminal(
+    program: &str,
+    args: &[String],
+    elevated_cwd: &Path,
+) -> std::io::Result<std::process::ExitStatus> {
+    let mut command = Command::new(program);
+    command.args(args);
+    #[cfg(unix)]
+    crate::invoking_user_command::prepare_external(&mut command, Some(elevated_cwd))?;
+    #[cfg(not(unix))]
+    let _ = elevated_cwd;
+    command.status()
 }
 
 #[cfg(unix)]
@@ -442,23 +452,35 @@ fn run_app(
             if let Some(task) = app.pending_terminal_task.take() {
                 let zoxide_result = match task {
                     PendingTerminalTask::Command { program, args } => {
+                        let cwd = app.navigation.cwd.clone();
                         pause_runtime_input(&input_reader, true);
                         suspend_terminal(terminal, drainer, true, kitty_dnd)?;
-                        run_blocking_in_terminal(&program, &args);
+                        let result = run_open_command_in_terminal(&program, &args, &cwd);
                         resume_terminal(terminal, drainer, kitty_dnd)?;
                         app.invalidate_terminal_image_overlay_after_terminal_task();
                         pause_runtime_input(&input_reader, false);
+                        if let Err(error) = result {
+                            app.set_status_message(format!("Could not open terminal app: {error}"));
+                        }
                         None
                     }
                     PendingTerminalTask::Commands(commands) => {
+                        let cwd = app.navigation.cwd.clone();
                         pause_runtime_input(&input_reader, true);
                         suspend_terminal(terminal, drainer, true, kitty_dnd)?;
+                        let mut last_error = None;
                         for (program, args) in commands {
-                            run_blocking_in_terminal(&program, &args);
+                            if let Err(error) = run_open_command_in_terminal(&program, &args, &cwd)
+                            {
+                                last_error = Some(error);
+                            }
                         }
                         resume_terminal(terminal, drainer, kitty_dnd)?;
                         app.invalidate_terminal_image_overlay_after_terminal_task();
                         pause_runtime_input(&input_reader, false);
+                        if let Some(error) = last_error {
+                            app.set_status_message(format!("Could not open terminal app: {error}"));
+                        }
                         None
                     }
                     #[cfg(unix)]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -148,7 +148,8 @@ fn unix_shell_launch(
     inherited_shell: Option<OsString>,
 ) -> Result<(Vec<ShellInvocation>, Option<crate::config::InvokingUser>), String> {
     match context {
-        crate::config::InvocationContext::Normal => {
+        crate::config::InvocationContext::Normal
+        | crate::config::InvocationContext::RootSession => {
             Ok((unix_shell_invocations(inherited_shell), None))
         }
         crate::config::InvocationContext::Elevated(user) => {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -288,6 +288,8 @@ mod tests {
             home: "/home/paco".into(),
             shell: OsString::from(shell),
             groups: vec![1000],
+            session_environment: Vec::new(),
+            xdg_config_home: None,
             xdg_data_home: None,
         }
     }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -31,26 +31,54 @@ pub(crate) fn run_in_current_terminal(cwd: &Path) -> Result<(), String> {
     ensure_cwd_exists(cwd)?;
     let cwd_label = crate::path_display::user_facing(cwd);
 
+    #[cfg(unix)]
+    let (invocations, invoking_user) = unix_shell_launch(
+        crate::config::invoking_user_context(),
+        std::env::var_os("SHELL"),
+    )?;
+    #[cfg(not(unix))]
     let invocations = shell_invocations();
     let tried: Vec<String> = invocations.iter().map(ShellInvocation::label).collect();
 
-    print_shell_banner(&cwd_label)?;
+    #[cfg(unix)]
+    print_shell_banner(
+        &cwd_label,
+        invoking_user.as_ref().map(|user| user.name.as_os_str()),
+    )?;
+    #[cfg(not(unix))]
+    print_shell_banner(&cwd_label, None)?;
+
     for invocation in invocations {
-        match Command::new(&invocation.program)
-            .args(&invocation.args)
-            .current_dir(cwd)
-            .env("ELIO_SHELL", "1")
-            .env(
-                "ELIO_LEVEL",
-                next_shell_level(std::env::var_os("ELIO_LEVEL")),
-            )
-            .status()
-        {
+        let mut command = Command::new(&invocation.program);
+        command.args(&invocation.args).env("ELIO_SHELL", "1").env(
+            "ELIO_LEVEL",
+            next_shell_level(std::env::var_os("ELIO_LEVEL")),
+        );
+
+        #[cfg(unix)]
+        if let Some(user) = &invoking_user {
+            crate::invoking_user_command::prepare(&mut command, user, Some(cwd)).map_err(
+                |error| format!("Could not prepare shell as invoking user in {cwd_label}: {error}"),
+            )?;
+        } else {
+            command.current_dir(cwd);
+        }
+        #[cfg(not(unix))]
+        command.current_dir(cwd);
+
+        match command.status() {
             Ok(_) => return Ok(()),
             Err(error) if error.kind() == ErrorKind::NotFound => {
                 ensure_cwd_exists(cwd)?;
             }
             Err(error) => {
+                #[cfg(unix)]
+                if let Some(user) = &invoking_user {
+                    return Err(format!(
+                        "Could not open shell as {} in {cwd_label}: {error}",
+                        user.name.to_string_lossy()
+                    ));
+                }
                 return Err(format!("Could not open shell in {cwd_label}: {error}"));
             }
         }
@@ -62,7 +90,7 @@ pub(crate) fn run_in_current_terminal(cwd: &Path) -> Result<(), String> {
     ))
 }
 
-fn print_shell_banner(cwd_label: &str) -> Result<(), String> {
+fn print_shell_banner(cwd_label: &str, user: Option<&std::ffi::OsStr>) -> Result<(), String> {
     let mut stdout = io::stdout();
     let (label_style, value_style, dim_style, reset_style) = if shell_banner_color_enabled() {
         ("\x1b[1;36m", "\x1b[1m", "\x1b[2m", "\x1b[0m")
@@ -70,21 +98,26 @@ fn print_shell_banner(cwd_label: &str) -> Result<(), String> {
         ("", "", "", "")
     };
 
-    writeln!(
-        stdout,
-        "{label_style}elio:{reset_style} opened shell in {value_style}{}{reset_style}",
-        cwd_label
-    )
-    .and_then(|()| {
-        writeln!(
-            stdout,
-            "{dim_style}return:{reset_style} {}",
-            shell_return_hint()
-        )
-    })
-    .and_then(|()| writeln!(stdout))
-    .and_then(|()| stdout.flush())
-    .map_err(|error| format!("Could not prepare shell in {cwd_label}: {error}"))
+    let opened = match user {
+        Some(user) => format!(
+            "{label_style}elio:{reset_style} opened shell as {value_style}{}{reset_style} in {value_style}{cwd_label}{reset_style}",
+            user.to_string_lossy()
+        ),
+        None => format!(
+            "{label_style}elio:{reset_style} opened shell in {value_style}{cwd_label}{reset_style}"
+        ),
+    };
+    writeln!(stdout, "{opened}")
+        .and_then(|()| {
+            writeln!(
+                stdout,
+                "{dim_style}return:{reset_style} {}",
+                shell_return_hint()
+            )
+        })
+        .and_then(|()| writeln!(stdout))
+        .and_then(|()| stdout.flush())
+        .map_err(|error| format!("Could not prepare shell in {cwd_label}: {error}"))
 }
 
 fn shell_banner_color_enabled() -> bool {
@@ -104,15 +137,26 @@ fn shell_return_hint() -> &'static str {
     }
 }
 
+#[cfg(windows)]
 pub(crate) fn shell_invocations() -> Vec<ShellInvocation> {
-    #[cfg(windows)]
-    {
-        windows_shell_invocations(std::env::var_os("COMSPEC"))
-    }
+    windows_shell_invocations(std::env::var_os("COMSPEC"))
+}
 
-    #[cfg(not(windows))]
-    {
-        unix_shell_invocations(std::env::var_os("SHELL"))
+#[cfg(unix)]
+fn unix_shell_launch(
+    context: crate::config::InvocationContext,
+    inherited_shell: Option<OsString>,
+) -> Result<(Vec<ShellInvocation>, Option<crate::config::InvokingUser>), String> {
+    match context {
+        crate::config::InvocationContext::Normal => {
+            Ok((unix_shell_invocations(inherited_shell), None))
+        }
+        crate::config::InvocationContext::Elevated(user) => {
+            Ok((unix_shell_invocations(Some(user.shell.clone())), Some(user)))
+        }
+        crate::config::InvocationContext::ElevatedUnresolved => {
+            Err("Could not resolve invoking user; shell was not opened".to_string())
+        }
     }
 }
 
@@ -232,6 +276,49 @@ mod tests {
                 program: OsString::from("/bin/sh"),
                 args: Vec::new(),
             }]
+        );
+    }
+
+    #[cfg(unix)]
+    fn test_invoking_user(shell: &str) -> crate::config::InvokingUser {
+        crate::config::InvokingUser {
+            uid: 1000,
+            gid: 1000,
+            name: OsString::from("paco"),
+            home: "/home/paco".into(),
+            shell: OsString::from(shell),
+            groups: vec![1000],
+            xdg_data_home: None,
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn elevated_shell_uses_passwd_shell_not_inherited_root_shell() {
+        let user = test_invoking_user("/bin/fish");
+        let (invocations, actual_user) = unix_shell_launch(
+            crate::config::InvocationContext::Elevated(user),
+            Some(OsString::from("/bin/root-shell")),
+        )
+        .unwrap();
+
+        assert_eq!(invocations[0].program, OsString::from("/bin/fish"));
+        assert_eq!(invocations[1].program, OsString::from("/bin/sh"));
+        assert_eq!(actual_user.unwrap().name, OsString::from("paco"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unresolved_elevated_shell_fails_closed() {
+        let error = unix_shell_launch(
+            crate::config::InvocationContext::ElevatedUnresolved,
+            Some(OsString::from("/bin/root-shell")),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            "Could not resolve invoking user; shell was not opened"
         );
     }
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -144,9 +144,9 @@ pub(crate) fn shell_invocations() -> Vec<ShellInvocation> {
 
 #[cfg(unix)]
 fn unix_shell_launch(
-    context: crate::config::InvocationContext,
+    context: &crate::config::InvocationContext,
     inherited_shell: Option<OsString>,
-) -> Result<(Vec<ShellInvocation>, Option<crate::config::InvokingUser>), String> {
+) -> Result<(Vec<ShellInvocation>, Option<&crate::config::InvokingUser>), String> {
     match context {
         crate::config::InvocationContext::Normal
         | crate::config::InvocationContext::RootSession => {
@@ -299,11 +299,9 @@ mod tests {
     #[test]
     fn elevated_shell_uses_passwd_shell_not_inherited_root_shell() {
         let user = test_invoking_user("/bin/fish");
-        let (invocations, actual_user) = unix_shell_launch(
-            crate::config::InvocationContext::Elevated(user),
-            Some(OsString::from("/bin/root-shell")),
-        )
-        .unwrap();
+        let context = crate::config::InvocationContext::Elevated(user);
+        let (invocations, actual_user) =
+            unix_shell_launch(&context, Some(OsString::from("/bin/root-shell"))).unwrap();
 
         assert_eq!(invocations[0].program, OsString::from("/bin/fish"));
         assert_eq!(invocations[1].program, OsString::from("/bin/sh"));
@@ -314,7 +312,7 @@ mod tests {
     #[test]
     fn unresolved_elevated_shell_fails_closed() {
         let error = unix_shell_launch(
-            crate::config::InvocationContext::ElevatedUnresolved,
+            &crate::config::InvocationContext::ElevatedUnresolved,
             Some(OsString::from("/bin/root-shell")),
         )
         .unwrap_err();

--- a/src/user_fs_helper.rs
+++ b/src/user_fs_helper.rs
@@ -12,12 +12,16 @@ const MAX_ITEMS: usize = 16_384;
 const MAX_PATH_BYTES: usize = 1024 * 1024;
 #[cfg(unix)]
 const MAX_ERROR_BYTES: usize = 16 * 1024;
+#[cfg(any(target_os = "macos", all(test, unix)))]
+const MAX_TOTAL_NAME_BYTES: usize = 16 * 1024 * 1024;
 
 #[cfg(unix)]
 #[derive(Debug)]
 pub(crate) enum Request {
     Trash(Vec<PathBuf>),
     Restore(PathBuf),
+    #[cfg(target_os = "macos")]
+    RemoveRestoreOrigins(Vec<String>),
 }
 
 #[cfg(unix)]
@@ -41,6 +45,8 @@ pub(crate) fn validate_request(request: &Request) -> io::Result<()> {
             }
         }
         Request::Restore(path) => validate_path(path)?,
+        #[cfg(target_os = "macos")]
+        Request::RemoveRestoreOrigins(names) => validate_restore_origin_names(names)?,
     }
     Ok(())
 }
@@ -60,6 +66,14 @@ pub(crate) fn write_request(mut writer: impl Write, request: &Request) -> io::Re
         Request::Restore(path) => {
             writer.write_all(&[2])?;
             write_path(&mut writer, path)?;
+        }
+        #[cfg(target_os = "macos")]
+        Request::RemoveRestoreOrigins(names) => {
+            writer.write_all(&[3])?;
+            write_u32(&mut writer, names.len())?;
+            for name in names {
+                write_bytes(&mut writer, name.as_bytes())?;
+            }
         }
     }
     Ok(())
@@ -90,6 +104,31 @@ pub(crate) fn read_request(mut reader: impl Read) -> io::Result<Request> {
             Ok(Request::Trash(paths))
         }
         2 => Ok(Request::Restore(read_path(&mut reader)?)),
+        #[cfg(target_os = "macos")]
+        3 => {
+            let count = read_u32(&mut reader)?;
+            if count > MAX_ITEMS {
+                return Err(io::Error::new(io::ErrorKind::InvalidData, "too many names"));
+            }
+            let mut names = Vec::with_capacity(count);
+            let mut total_bytes = 0usize;
+            for _ in 0..count {
+                let bytes = read_bytes(&mut reader)?;
+                total_bytes = total_bytes.checked_add(bytes.len()).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "names are too large")
+                })?;
+                if total_bytes > MAX_TOTAL_NAME_BYTES {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "names are too large",
+                    ));
+                }
+                let name = String::from_utf8(bytes)
+                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "name is not UTF-8"))?;
+                names.push(name);
+            }
+            Ok(Request::RemoveRestoreOrigins(names))
+        }
         _ => Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "unknown request",
@@ -151,6 +190,34 @@ fn validate_path(path: &std::path::Path) -> io::Result<()> {
     Ok(())
 }
 
+#[cfg(any(target_os = "macos", all(test, unix)))]
+fn validate_restore_origin_names(names: &[String]) -> io::Result<()> {
+    if names.len() > MAX_ITEMS {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "too many names",
+        ));
+    }
+    let total_bytes = names.iter().try_fold(0usize, |total, name| {
+        if name.len() > MAX_PATH_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "name too large",
+            ));
+        }
+        total
+            .checked_add(name.len())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "names are too large"))
+    })?;
+    if total_bytes > MAX_TOTAL_NAME_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "names are too large",
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(unix)]
 fn read_path(reader: impl Read) -> io::Result<PathBuf> {
     Ok(PathBuf::from(OsString::from_vec(read_bytes(reader)?)))
@@ -202,19 +269,62 @@ pub fn run() -> anyhow::Result<()> {
     let request = read_request(io::stdin().lock())?;
     let response = match request {
         Request::Trash(paths) => crate::app::run_user_trash_helper(&paths),
-        Request::Restore(path) => match crate::fs::restore_trash_item(&path) {
-            Ok(()) => Response {
-                completed: 1,
-                error: None,
-            },
-            Err(error) => Response {
-                completed: 0,
-                error: Some(error.to_string()),
-            },
-        },
+        Request::Restore(path) => restore_response(&path),
+        #[cfg(target_os = "macos")]
+        Request::RemoveRestoreOrigins(names) => {
+            let names_ref = names.iter().map(String::as_str).collect::<Vec<_>>();
+            match crate::fs::remove_restore_origins_checked(&names_ref) {
+                Ok(()) => Response {
+                    completed: names.len(),
+                    error: None,
+                },
+                Err(error) => Response {
+                    completed: 0,
+                    error: Some(error.to_string()),
+                },
+            }
+        }
     };
     write_response(io::stdout().lock(), &response)?;
     Ok(())
+}
+
+#[cfg(unix)]
+fn restore_response(path: &std::path::Path) -> Response {
+    #[cfg(target_os = "macos")]
+    {
+        return checked_restore_response(crate::fs::restore_trash_item_checked_metadata(path));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    match crate::fs::restore_trash_item(path) {
+        Ok(()) => Response {
+            completed: 1,
+            error: None,
+        },
+        Err(error) => Response {
+            completed: 0,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+#[cfg(any(target_os = "macos", all(test, unix)))]
+fn checked_restore_response(result: anyhow::Result<Option<anyhow::Error>>) -> Response {
+    match result {
+        Ok(None) => Response {
+            completed: 1,
+            error: None,
+        },
+        Ok(Some(error)) => Response {
+            completed: 1,
+            error: Some(format!("could not update Trash restore metadata: {error}")),
+        },
+        Err(error) => Response {
+            completed: 0,
+            error: Some(error.to_string()),
+        },
+    }
 }
 
 #[cfg(unix)]
@@ -340,5 +450,54 @@ mod tests {
         let decoded = read_response(bytes.as_slice()).unwrap();
         assert_eq!(decoded.completed, 7);
         assert_eq!(decoded.error.unwrap().len(), MAX_ERROR_BYTES);
+    }
+
+    #[test]
+    fn restore_origin_names_are_bounded() {
+        assert!(validate_restore_origin_names(&["report.pdf".to_string()]).is_ok());
+        assert_eq!(
+            validate_restore_origin_names(&vec!["name".to_string(); MAX_ITEMS + 1])
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert_eq!(
+            validate_restore_origin_names(&["x".repeat(MAX_PATH_BYTES + 1)])
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn checked_restore_distinguishes_metadata_warning_from_restore_failure() {
+        let warning = checked_restore_response(Ok(Some(anyhow::anyhow!("store is read-only"))));
+        assert_eq!(warning.completed, 1);
+        assert_eq!(
+            warning.error.as_deref(),
+            Some("could not update Trash restore metadata: store is read-only")
+        );
+
+        let failure = checked_restore_response(Err(anyhow::anyhow!("permission denied")));
+        assert_eq!(failure.completed, 0);
+        assert_eq!(failure.error.as_deref(), Some("permission denied"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn remove_restore_origins_round_trips_names() {
+        let request = Request::RemoveRestoreOrigins(vec![
+            "report.pdf".to_string(),
+            "report 2.pdf".to_string(),
+        ]);
+        let mut bytes = Vec::new();
+        write_request(&mut bytes, &request).unwrap();
+        let Request::RemoveRestoreOrigins(names) = read_request(bytes.as_slice()).unwrap() else {
+            panic!("wrong request type");
+        };
+        assert_eq!(
+            names,
+            vec!["report.pdf".to_string(), "report 2.pdf".to_string()]
+        );
     }
 }

--- a/src/user_fs_helper.rs
+++ b/src/user_fs_helper.rs
@@ -28,6 +28,7 @@ pub(crate) enum Request {
 pub(crate) struct Response {
     pub(crate) completed: usize,
     pub(crate) error: Option<String>,
+    pub(crate) warning: Option<String>,
 }
 
 #[cfg(unix)]
@@ -138,14 +139,26 @@ pub(crate) fn read_request(mut reader: impl Read) -> io::Result<Request> {
 
 #[cfg(unix)]
 pub(crate) fn write_response(mut writer: impl Write, response: &Response) -> io::Result<()> {
+    if response.error.is_some() && response.warning.is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "response cannot contain both an error and a warning",
+        ));
+    }
     writer.write_all(&(response.completed as u64).to_le_bytes())?;
-    match &response.error {
-        Some(error) => {
+    match (&response.error, &response.warning) {
+        (Some(_), Some(_)) => unreachable!("response fields were validated"),
+        (Some(error), None) => {
             writer.write_all(&[1])?;
             let bytes = error.as_bytes();
             write_bytes(&mut writer, &bytes[..bytes.len().min(MAX_ERROR_BYTES)])?;
         }
-        None => writer.write_all(&[0])?,
+        (None, Some(warning)) => {
+            writer.write_all(&[2])?;
+            let bytes = warning.as_bytes();
+            write_bytes(&mut writer, &bytes[..bytes.len().min(MAX_ERROR_BYTES)])?;
+        }
+        (None, None) => writer.write_all(&[0])?,
     }
     Ok(())
 }
@@ -154,11 +167,18 @@ pub(crate) fn write_response(mut writer: impl Write, response: &Response) -> io:
 pub(crate) fn read_response(mut reader: impl Read) -> io::Result<Response> {
     let mut completed = [0; 8];
     reader.read_exact(&mut completed)?;
-    let mut failed = [0];
-    reader.read_exact(&mut failed)?;
-    let error = match failed[0] {
-        0 => None,
-        1 => Some(String::from_utf8_lossy(&read_bytes(&mut reader)?).into_owned()),
+    let mut message_kind = [0];
+    reader.read_exact(&mut message_kind)?;
+    let (error, warning) = match message_kind[0] {
+        0 => (None, None),
+        1 => (
+            Some(String::from_utf8_lossy(&read_bytes(&mut reader)?).into_owned()),
+            None,
+        ),
+        2 => (
+            None,
+            Some(String::from_utf8_lossy(&read_bytes(&mut reader)?).into_owned()),
+        ),
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -169,6 +189,7 @@ pub(crate) fn read_response(mut reader: impl Read) -> io::Result<Response> {
     Ok(Response {
         completed: u64::from_le_bytes(completed) as usize,
         error,
+        warning,
     })
 }
 
@@ -277,10 +298,12 @@ pub fn run() -> anyhow::Result<()> {
                 Ok(()) => Response {
                     completed: names.len(),
                     error: None,
+                    warning: None,
                 },
                 Err(error) => Response {
                     completed: 0,
                     error: Some(error.to_string()),
+                    warning: None,
                 },
             }
         }
@@ -301,10 +324,12 @@ fn restore_response(path: &std::path::Path) -> Response {
         Ok(()) => Response {
             completed: 1,
             error: None,
+            warning: None,
         },
         Err(error) => Response {
             completed: 0,
             error: Some(error.to_string()),
+            warning: None,
         },
     }
 }
@@ -315,14 +340,17 @@ fn checked_restore_response(result: anyhow::Result<Option<anyhow::Error>>) -> Re
         Ok(None) => Response {
             completed: 1,
             error: None,
+            warning: None,
         },
         Ok(Some(error)) => Response {
             completed: 1,
-            error: Some(format!("could not update Trash restore metadata: {error}")),
+            error: None,
+            warning: Some(format!("could not update Trash restore metadata: {error}")),
         },
         Err(error) => Response {
             completed: 0,
             error: Some(error.to_string()),
+            warning: None,
         },
     }
 }
@@ -444,12 +472,50 @@ mod tests {
         let response = Response {
             completed: 7,
             error: Some("x".repeat(MAX_PATH_BYTES + 1)),
+            warning: None,
         };
         let mut bytes = Vec::new();
         write_response(&mut bytes, &response).unwrap();
         let decoded = read_response(bytes.as_slice()).unwrap();
         assert_eq!(decoded.completed, 7);
         assert_eq!(decoded.error.unwrap().len(), MAX_ERROR_BYTES);
+        assert!(decoded.warning.is_none());
+    }
+
+    #[test]
+    fn response_round_trips_warning_separately_from_error() {
+        let response = Response {
+            completed: 2,
+            error: None,
+            warning: Some("restore metadata is unavailable".to_string()),
+        };
+        let mut bytes = Vec::new();
+
+        write_response(&mut bytes, &response).unwrap();
+        let decoded = read_response(bytes.as_slice()).unwrap();
+
+        assert_eq!(decoded.completed, 2);
+        assert!(decoded.error.is_none());
+        assert_eq!(
+            decoded.warning.as_deref(),
+            Some("restore metadata is unavailable")
+        );
+    }
+
+    #[test]
+    fn response_rejects_error_and_warning_together_before_writing() {
+        let response = Response {
+            completed: 1,
+            error: Some("failure".to_string()),
+            warning: Some("warning".to_string()),
+        };
+        let mut bytes = Vec::new();
+
+        assert_eq!(
+            write_response(&mut bytes, &response).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert!(bytes.is_empty());
     }
 
     #[test]
@@ -474,13 +540,15 @@ mod tests {
         let warning = checked_restore_response(Ok(Some(anyhow::anyhow!("store is read-only"))));
         assert_eq!(warning.completed, 1);
         assert_eq!(
-            warning.error.as_deref(),
+            warning.warning.as_deref(),
             Some("could not update Trash restore metadata: store is read-only")
         );
+        assert!(warning.error.is_none());
 
         let failure = checked_restore_response(Err(anyhow::anyhow!("permission denied")));
         assert_eq!(failure.completed, 0);
         assert_eq!(failure.error.as_deref(), Some("permission denied"));
+        assert!(failure.warning.is_none());
     }
 
     #[cfg(target_os = "macos")]
@@ -488,7 +556,7 @@ mod tests {
     fn remove_restore_origins_round_trips_names() {
         let request = Request::RemoveRestoreOrigins(vec![
             "report.pdf".to_string(),
-            "report 2.pdf".to_string(),
+            "report 11.53.48.pdf".to_string(),
         ]);
         let mut bytes = Vec::new();
         write_request(&mut bytes, &request).unwrap();
@@ -497,7 +565,7 @@ mod tests {
         };
         assert_eq!(
             names,
-            vec!["report.pdf".to_string(), "report 2.pdf".to_string()]
+            vec!["report.pdf".to_string(), "report 11.53.48.pdf".to_string()]
         );
     }
 }

--- a/src/user_fs_helper.rs
+++ b/src/user_fs_helper.rs
@@ -1,0 +1,344 @@
+#[cfg(unix)]
+use std::{
+    ffi::OsString,
+    io::{self, Read, Write},
+    os::unix::ffi::OsStringExt,
+    path::PathBuf,
+};
+
+#[cfg(unix)]
+const MAX_ITEMS: usize = 16_384;
+#[cfg(unix)]
+const MAX_PATH_BYTES: usize = 1024 * 1024;
+#[cfg(unix)]
+const MAX_ERROR_BYTES: usize = 16 * 1024;
+
+#[cfg(unix)]
+#[derive(Debug)]
+pub(crate) enum Request {
+    Trash(Vec<PathBuf>),
+    Restore(PathBuf),
+}
+
+#[cfg(unix)]
+pub(crate) struct Response {
+    pub(crate) completed: usize,
+    pub(crate) error: Option<String>,
+}
+
+#[cfg(unix)]
+pub(crate) fn validate_request(request: &Request) -> io::Result<()> {
+    match request {
+        Request::Trash(paths) => {
+            if paths.len() > MAX_ITEMS {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "too many paths",
+                ));
+            }
+            for path in paths {
+                validate_path(path)?;
+            }
+        }
+        Request::Restore(path) => validate_path(path)?,
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) fn write_request(mut writer: impl Write, request: &Request) -> io::Result<()> {
+    validate_request(request)?;
+    writer.write_all(b"EU\x01")?;
+    match request {
+        Request::Trash(paths) => {
+            writer.write_all(&[1])?;
+            write_u32(&mut writer, paths.len())?;
+            for path in paths {
+                write_path(&mut writer, path)?;
+            }
+        }
+        Request::Restore(path) => {
+            writer.write_all(&[2])?;
+            write_path(&mut writer, path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) fn read_request(mut reader: impl Read) -> io::Result<Request> {
+    let mut header = [0; 3];
+    reader.read_exact(&mut header)?;
+    if header != *b"EU\x01" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unsupported helper protocol",
+        ));
+    }
+    let mut opcode = [0];
+    reader.read_exact(&mut opcode)?;
+    match opcode[0] {
+        1 => {
+            let count = read_u32(&mut reader)?;
+            if count > MAX_ITEMS {
+                return Err(io::Error::new(io::ErrorKind::InvalidData, "too many paths"));
+            }
+            let mut paths = Vec::with_capacity(count);
+            for _ in 0..count {
+                paths.push(read_path(&mut reader)?);
+            }
+            Ok(Request::Trash(paths))
+        }
+        2 => Ok(Request::Restore(read_path(&mut reader)?)),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unknown request",
+        )),
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn write_response(mut writer: impl Write, response: &Response) -> io::Result<()> {
+    writer.write_all(&(response.completed as u64).to_le_bytes())?;
+    match &response.error {
+        Some(error) => {
+            writer.write_all(&[1])?;
+            let bytes = error.as_bytes();
+            write_bytes(&mut writer, &bytes[..bytes.len().min(MAX_ERROR_BYTES)])?;
+        }
+        None => writer.write_all(&[0])?,
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) fn read_response(mut reader: impl Read) -> io::Result<Response> {
+    let mut completed = [0; 8];
+    reader.read_exact(&mut completed)?;
+    let mut failed = [0];
+    reader.read_exact(&mut failed)?;
+    let error = match failed[0] {
+        0 => None,
+        1 => Some(String::from_utf8_lossy(&read_bytes(&mut reader)?).into_owned()),
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid response",
+            ));
+        }
+    };
+    Ok(Response {
+        completed: u64::from_le_bytes(completed) as usize,
+        error,
+    })
+}
+
+#[cfg(unix)]
+fn write_path(writer: impl Write, path: &std::path::Path) -> io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    write_bytes(writer, path.as_os_str().as_bytes())
+}
+
+#[cfg(unix)]
+fn validate_path(path: &std::path::Path) -> io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    if path.as_os_str().as_bytes().len() > MAX_PATH_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "path too large",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn read_path(reader: impl Read) -> io::Result<PathBuf> {
+    Ok(PathBuf::from(OsString::from_vec(read_bytes(reader)?)))
+}
+
+#[cfg(unix)]
+fn write_u32(mut writer: impl Write, value: usize) -> io::Result<()> {
+    let value = u32::try_from(value)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "value too large"))?;
+    writer.write_all(&value.to_le_bytes())
+}
+
+#[cfg(unix)]
+fn read_u32(mut reader: impl Read) -> io::Result<usize> {
+    let mut bytes = [0; 4];
+    reader.read_exact(&mut bytes)?;
+    Ok(u32::from_le_bytes(bytes) as usize)
+}
+
+#[cfg(unix)]
+fn write_bytes(mut writer: impl Write, bytes: &[u8]) -> io::Result<()> {
+    if bytes.len() > MAX_PATH_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "frame too large",
+        ));
+    }
+    write_u32(&mut writer, bytes.len())?;
+    writer.write_all(bytes)
+}
+
+#[cfg(unix)]
+fn read_bytes(mut reader: impl Read) -> io::Result<Vec<u8>> {
+    let len = read_u32(&mut reader)?;
+    if len > MAX_PATH_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "frame too large",
+        ));
+    }
+    let mut bytes = vec![0; len];
+    reader.read_exact(&mut bytes)?;
+    Ok(bytes)
+}
+
+#[cfg(unix)]
+pub fn run() -> anyhow::Result<()> {
+    validate_credentials()?;
+    let request = read_request(io::stdin().lock())?;
+    let response = match request {
+        Request::Trash(paths) => crate::app::run_user_trash_helper(&paths),
+        Request::Restore(path) => match crate::fs::restore_trash_item(&path) {
+            Ok(()) => Response {
+                completed: 1,
+                error: None,
+            },
+            Err(error) => Response {
+                completed: 0,
+                error: Some(error.to_string()),
+            },
+        },
+    };
+    write_response(io::stdout().lock(), &response)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_credentials() -> anyhow::Result<()> {
+    let expected_uid = std::env::var("ELIO_HELPER_UID")?.parse::<libc::uid_t>()?;
+    let expected_gid = std::env::var("ELIO_HELPER_GID")?.parse::<libc::gid_t>()?;
+    let mut expected_groups = std::env::var("ELIO_HELPER_GROUPS")?
+        .split(',')
+        .map(str::parse::<libc::gid_t>)
+        .collect::<Result<Vec<_>, _>>()?;
+    let (uid, euid, gid, egid) = unsafe {
+        (
+            libc::getuid(),
+            libc::geteuid(),
+            libc::getgid(),
+            libc::getegid(),
+        )
+    };
+    anyhow::ensure!(
+        expected_uid != 0 && uid == expected_uid && euid == expected_uid,
+        "invalid helper uid"
+    );
+    anyhow::ensure!(
+        gid == expected_gid && egid == expected_gid,
+        "invalid helper gid"
+    );
+    let mut group_count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+    anyhow::ensure!(group_count >= 0, "cannot read helper groups");
+    let mut groups = vec![0; group_count as usize];
+    group_count = unsafe { libc::getgroups(group_count, groups.as_mut_ptr()) };
+    anyhow::ensure!(group_count >= 0, "cannot read helper groups");
+    groups.truncate(group_count as usize);
+    groups.sort_unstable();
+    groups.dedup();
+    expected_groups.sort_unstable();
+    expected_groups.dedup();
+    anyhow::ensure!(groups == expected_groups, "invalid helper groups");
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    {
+        let (mut real_uid, mut effective_uid, mut saved_uid) = (0, 0, 0);
+        let (mut real_gid, mut effective_gid, mut saved_gid) = (0, 0, 0);
+        anyhow::ensure!(
+            unsafe { libc::getresuid(&mut real_uid, &mut effective_uid, &mut saved_uid) } == 0,
+            "cannot read helper uid state"
+        );
+        anyhow::ensure!(
+            unsafe { libc::getresgid(&mut real_gid, &mut effective_gid, &mut saved_gid) } == 0,
+            "cannot read helper gid state"
+        );
+        anyhow::ensure!(
+            real_uid == expected_uid && effective_uid == expected_uid && saved_uid == expected_uid,
+            "invalid saved helper uid"
+        );
+        anyhow::ensure!(
+            real_gid == expected_gid && effective_gid == expected_gid && saved_gid == expected_gid,
+            "invalid saved helper gid"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn run() -> anyhow::Result<()> {
+    anyhow::bail!("user filesystem helper is unsupported on this platform")
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::ffi::OsStrExt;
+
+    #[test]
+    fn protocol_round_trips_non_utf8_paths() {
+        let path = PathBuf::from(OsString::from_vec(b"/tmp/a\xffb".to_vec()));
+        let request = Request::Trash(vec![path.clone()]);
+        let mut bytes = Vec::new();
+        write_request(&mut bytes, &request).unwrap();
+        let Request::Trash(paths) = read_request(bytes.as_slice()).unwrap() else {
+            panic!("wrong request type");
+        };
+        assert_eq!(paths[0].as_os_str().as_bytes(), path.as_os_str().as_bytes());
+    }
+
+    #[test]
+    fn protocol_rejects_oversized_frame() {
+        let mut bytes = b"EU\x01".to_vec();
+        bytes.push(2);
+        bytes.extend_from_slice(&((MAX_PATH_BYTES as u32) + 1).to_le_bytes());
+        assert_eq!(
+            read_request(bytes.as_slice()).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn protocol_rejects_unknown_version() {
+        let bytes = b"EU\x02\x02";
+        assert_eq!(
+            read_request(bytes.as_slice()).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn request_rejects_too_many_items_before_writing() {
+        let request = Request::Trash(vec![PathBuf::from("/tmp/a"); MAX_ITEMS + 1]);
+        let mut bytes = Vec::new();
+        assert_eq!(
+            write_request(&mut bytes, &request).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn response_truncates_error_without_losing_completion() {
+        let response = Response {
+            completed: 7,
+            error: Some("x".repeat(MAX_PATH_BYTES + 1)),
+        };
+        let mut bytes = Vec::new();
+        write_response(&mut bytes, &response).unwrap();
+        let decoded = read_response(bytes.as_slice()).unwrap();
+        assert_eq!(decoded.completed, 7);
+        assert_eq!(decoded.error.unwrap().len(), MAX_ERROR_BYTES);
+    }
+}

--- a/src/zoxide.rs
+++ b/src/zoxide.rs
@@ -1,8 +1,11 @@
 use std::{
-    env, io,
+    io,
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
+
+#[cfg(not(unix))]
+use std::env;
 
 #[cfg(unix)]
 use std::ffi::OsString;
@@ -34,7 +37,11 @@ pub(crate) fn preflight(cwd: &Path) -> Option<QueryResult> {
 }
 
 pub(crate) fn run_query_in_terminal(cwd: &Path) -> QueryResult {
-    let output = match Command::new("zoxide")
+    let mut command = match zoxide_command() {
+        Ok(command) => command,
+        Err(_) => return QueryResult::LaunchFailed,
+    };
+    let output = match command
         .args(["query", "-i", "--exclude"])
         .arg(cwd)
         .env("SHELL", "sh")
@@ -63,7 +70,7 @@ pub(crate) fn run_query_in_terminal(cwd: &Path) -> QueryResult {
 }
 
 fn has_match_excluding(cwd: &Path) -> io::Result<bool> {
-    let output = Command::new("zoxide")
+    let output = zoxide_command()?
         .args(["query", "-l", "--exclude"])
         .arg(cwd)
         .output()?;
@@ -71,8 +78,22 @@ fn has_match_excluding(cwd: &Path) -> io::Result<bool> {
 }
 
 fn has_any_match() -> io::Result<bool> {
-    let output = Command::new("zoxide").args(["query", "-l"]).output()?;
+    let output = zoxide_command()?.args(["query", "-l"]).output()?;
     Ok(!output.stdout.is_empty())
+}
+
+fn zoxide_command() -> io::Result<Command> {
+    let command = Command::new("zoxide");
+    #[cfg(unix)]
+    {
+        let mut command = command;
+        crate::invoking_user_command::prepare_external(&mut command, None)?;
+        Ok(command)
+    }
+    #[cfg(not(unix))]
+    {
+        Ok(command)
+    }
 }
 
 fn stderr_mentions_missing_fzf(stderr: &[u8]) -> bool {
@@ -87,13 +108,29 @@ fn stderr_mentions_missing_fzf(stderr: &[u8]) -> bool {
 }
 
 fn fzf_options() -> String {
+    fzf_options_with(invoking_user_environment_string)
+}
+
+fn invoking_user_environment_string(name: &str) -> Option<String> {
+    #[cfg(unix)]
+    let value = crate::config::invoking_user_env_var(name);
+    #[cfg(not(unix))]
+    let value = env::var_os(name);
+
+    value.and_then(|value| value.into_string().ok())
+}
+
+fn fzf_options_with(mut environment_value: impl FnMut(&str) -> Option<String>) -> String {
     let defaults = fzf_default_options().join(" ");
 
-    match (env::var("FZF_DEFAULT_OPTS"), env::var("ELIO_ZOXIDE_OPTS")) {
-        (Ok(base), Ok(extra)) => format!("{base} {defaults} {extra}"),
-        (Ok(base), Err(_)) => format!("{base} {defaults}"),
-        (Err(_), Ok(extra)) => format!("{defaults} {extra}"),
-        (Err(_), Err(_)) => defaults,
+    match (
+        environment_value("FZF_DEFAULT_OPTS"),
+        environment_value("ELIO_ZOXIDE_OPTS"),
+    ) {
+        (Some(base), Some(extra)) => format!("{base} {defaults} {extra}"),
+        (Some(base), None) => format!("{base} {defaults}"),
+        (None, Some(extra)) => format!("{defaults} {extra}"),
+        (None, None) => defaults,
     }
 }
 
@@ -156,7 +193,20 @@ fn path_from_command_stdout(mut stdout: Vec<u8>) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod fzf_tests {
-    use super::fzf_default_options;
+    use super::{fzf_default_options, fzf_options_with};
+
+    #[test]
+    fn fzf_options_use_invoking_user_values() {
+        let options = fzf_options_with(|name| match name {
+            "FZF_DEFAULT_OPTS" => Some("--height=40%".to_string()),
+            "ELIO_ZOXIDE_OPTS" => Some("--no-mouse".to_string()),
+            _ => None,
+        });
+
+        assert!(options.starts_with("--height=40% "));
+        assert!(options.ends_with(" --no-mouse"));
+        assert!(options.contains("--exact"));
+    }
 
     #[test]
     fn fzf_options_include_base_picker_flags() {


### PR DESCRIPTION
## Summary

Use the invoking user's config, Home, Places, Trash, shell, applications, editor, and zoxide when Elio runs through `sudo` or `doas`, while retaining elevated filesystem access.

Direct-root sessions continue using root's state, malformed elevation metadata fails closed, and macOS Trash tracks Finder-assigned collision names for correct Restore behavior.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

Manual checks:

- Linux: exercised normal, plain `sudo`, `sudo -E`, explicit root environment overrides, direct-root, and malformed elevation sessions; verified config, Home, Places, Trash/Restore, permanent deletion, shell, Rename in Editor, Open/Open With, zoxide, ownership, and privilege boundaries.
- FreeBSD: exercised normal, plain `doas`, explicit root environment overrides, direct-root, and malformed elevation sessions; verified config, Home, Places, Trash/Restore, permanent deletion, shell, Rename in Editor, Open/Open With, zoxide, ownership, and privilege boundaries.
- macOS: exercised normal, plain `sudo`, `sudo -E`, explicit root environment overrides, direct-root, and malformed elevation sessions; verified config, Home, Places, Trash/Restore, permanent deletion, shell, Rename in Editor, Open/Open With, metadata ownership, protected-file boundaries, and Finder collision names.
- Windows: confirmed the branch remains compatible on a native Windows environment.

## Documentation and Changelog

- [ ] Updated docs when behavior, configuration, controls, or optional dependencies changed
- [x] Added a `CHANGELOG.md` entry for user-visible changes
- [ ] Docs and changelog are not needed