### PR TITLE
feat(cli): add config and theme path overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added bulk archive extraction for selected archives. ([#241])
 - Added a Nord example theme. ([#270])
 - Added invoking-user-aware `sudo` and `doas` sessions on Unix: elio retains elevated filesystem access while using the invoking user's config, Places, shell, applications, editor, zoxide, and Trash/Restore; direct-root sessions continue using root's state.
+- Added `--config FILE` and `--theme FILE` to override the default configuration and theme paths. ([#274])
 
 ### Changed
 
@@ -330,6 +331,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/elio-fm/elio/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/elio-fm/elio/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/elio-fm/elio/releases/tag/v1.0.0
+[#274]: https://github.com/elio-fm/elio/issues/274
 [#270]: https://github.com/elio-fm/elio/issues/270
 [#267]: https://github.com/elio-fm/elio/issues/267
 [#258]: https://github.com/elio-fm/elio/issues/258

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ elio reads configuration from:
 | macOS | `~/.config/elio/config.toml` or `~/Library/Application Support/elio/config.toml` |
 | Windows | `%APPDATA%\elio\config.toml` |
 
+Use `elio --config FILE` to load configuration from a custom path instead of the default location.
+
 See [`examples/config.toml`](examples/config.toml) for an annotated example, or the configuration docs:
 https://elio-fm.github.io/docs/configuration/
 
@@ -220,6 +222,8 @@ elio themes are TOML files layered on top of the built-in defaults, so you only 
 | Linux / BSD | `~/.config/elio/theme.toml` or `$XDG_CONFIG_HOME/elio/theme.toml` |
 | macOS | `~/.config/elio/theme.toml` or `~/Library/Application Support/elio/theme.toml` |
 | Windows | `%APPDATA%\elio\theme.toml` |
+
+Use `elio --theme FILE` to load a theme from a custom path instead of the default location.
 
 See [`assets/themes/default/theme.toml`](assets/themes/default/theme.toml) for the full default theme and [`examples/themes/`](examples/themes/) for ready-made themes.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,8 @@ pub(crate) fn run() -> Result<ExitCode> {
         Command::Run {
             options,
             chooser_file,
+            config_file,
+            theme_file,
             start_focus,
             reveal_hidden_start_focus,
         } => elio::run_with_startup_options(
@@ -22,6 +24,8 @@ pub(crate) fn run() -> Result<ExitCode> {
             start_focus,
             reveal_hidden_start_focus,
             chooser_file,
+            config_file,
+            theme_file,
         )
         .map(run_outcome_exit_code),
         Command::PrintVersion => {
@@ -106,6 +110,8 @@ enum Command {
     Run {
         options: elio::RunOptions,
         chooser_file: Option<PathBuf>,
+        config_file: Option<PathBuf>,
+        theme_file: Option<PathBuf>,
         start_focus: Option<PathBuf>,
         reveal_hidden_start_focus: bool,
     },
@@ -124,6 +130,8 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Command> {
         return Ok(Command::Run {
             options: elio::RunOptions::default(),
             chooser_file: None,
+            config_file: None,
+            theme_file: None,
             start_focus: None,
             reveal_hidden_start_focus: false,
         });
@@ -206,6 +214,8 @@ fn parse_run_args(args: Vec<String>) -> Result<Command> {
     let mut reveal_hidden_start_focus = false;
     let mut cwd_file = None;
     let mut chooser_file = None;
+    let mut config_file = None;
+    let mut theme_file = None;
     let mut index = 0;
 
     while index < args.len() {
@@ -234,6 +244,30 @@ fn parse_run_args(args: Vec<String>) -> Result<Command> {
             continue;
         }
 
+        if path_option_matches(arg, "--config") {
+            if config_file.is_some() {
+                return Err(anyhow::anyhow!(
+                    "error: '--config' cannot be used more than once\n\n{RUN_USAGE}"
+                ));
+            }
+            let (file, next_index) = take_path_option_value(&args, index, "--config")?;
+            config_file = Some(file);
+            index = next_index;
+            continue;
+        }
+
+        if path_option_matches(arg, "--theme") {
+            if theme_file.is_some() {
+                return Err(anyhow::anyhow!(
+                    "error: '--theme' cannot be used more than once\n\n{RUN_USAGE}"
+                ));
+            }
+            let (file, next_index) = take_path_option_value(&args, index, "--theme")?;
+            theme_file = Some(file);
+            index = next_index;
+            continue;
+        }
+
         if arg.starts_with('-') {
             return Err(anyhow::anyhow!(unknown_argument_message(arg)));
         }
@@ -254,6 +288,8 @@ fn parse_run_args(args: Vec<String>) -> Result<Command> {
             cwd_file,
         },
         chooser_file,
+        config_file,
+        theme_file,
         start_focus,
         reveal_hidden_start_focus,
     })
@@ -309,9 +345,11 @@ fn print_help() {
     println!();
     println!("Options:");
     println!("      --chooser-file FILE  Write chosen paths to FILE, or stdout with '-'");
-    println!("      --cwd-file FILE  Write the final current directory to FILE on exit");
-    println!("  -h, --help           Print help");
-    println!("  -V, --version        Print version");
+    println!("      --config FILE        Load configuration from FILE");
+    println!("      --cwd-file FILE      Write the final current directory to FILE on exit");
+    println!("      --theme FILE         Load theme from FILE");
+    println!("  -h, --help               Print help");
+    println!("  -V, --version            Print version");
     println!();
     println!("Commands:");
     println!("  shell init <SHELL>        Print shell integration for bash, zsh, fish, or nu");
@@ -401,6 +439,10 @@ fn unknown_argument_message(arg: &str) -> String {
         message.push_str("\n\n  tip: a similar argument exists: '--cwd-file'");
     } else if arg != "--chooser-file" && "--chooser-file".starts_with(arg) {
         message.push_str("\n\n  tip: a similar argument exists: '--chooser-file'");
+    } else if arg != "--config" && "--config".starts_with(arg) {
+        message.push_str("\n\n  tip: a similar argument exists: '--config'");
+    } else if arg != "--theme" && "--theme".starts_with(arg) {
+        message.push_str("\n\n  tip: a similar argument exists: '--theme'");
     }
 
     message.push_str("\n\n");
@@ -411,7 +453,7 @@ fn unknown_argument_message(arg: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{StartupPath, resolve_startup_path};
+    use super::{Command, StartupPath, parse_args, resolve_startup_path};
     use std::{
         fs,
         path::PathBuf,
@@ -424,6 +466,27 @@ mod tests {
             .expect("system time should be after unix epoch")
             .as_nanos();
         std::env::temp_dir().join(format!("elio-cli-{label}-{unique}"))
+    }
+
+    #[test]
+    fn config_and_theme_options_accept_separate_and_inline_paths() {
+        let command = parse_args([
+            "--theme=/tmp/custom-theme.toml".to_string(),
+            "--config".to_string(),
+            "/tmp/custom-config.toml".to_string(),
+        ])
+        .expect("config and theme options should parse");
+
+        let Command::Run {
+            config_file,
+            theme_file,
+            ..
+        } = command
+        else {
+            panic!("config and theme options should produce a run command");
+        };
+        assert_eq!(config_file, Some(PathBuf::from("/tmp/custom-config.toml")));
+        assert_eq!(theme_file, Some(PathBuf::from("/tmp/custom-theme.toml")));
     }
 
     #[test]

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -1,14 +1,20 @@
 use super::Config;
 #[cfg(unix)]
 use super::invoking_user::InvocationContext;
-#[cfg(unix)]
-use std::path::Path;
-use std::{env, fs, io, path::PathBuf, sync::OnceLock};
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
 
 static ACTIVE_CONFIG: OnceLock<Config> = OnceLock::new();
 
-pub(super) fn initialize() {
-    let _ = ACTIVE_CONFIG.get_or_init(load_config_from_disk);
+pub(super) fn initialize(path: Option<&Path>) -> anyhow::Result<()> {
+    if ACTIVE_CONFIG.get().is_none() {
+        let config = load_config_from_disk(path)?;
+        let _ = ACTIVE_CONFIG.set(config);
+    }
+    Ok(())
 }
 
 pub(super) fn active_config() -> &'static Config {
@@ -83,23 +89,32 @@ fn platform_config_home(xdg_home: Option<&Path>, home: Option<&Path>) -> Option<
     Some(home.join(".config"))
 }
 
-fn load_config_from_disk() -> Config {
-    let Some(path) = config_path() else {
-        return Config::default_config();
+fn load_config_from_disk(override_path: Option<&Path>) -> anyhow::Result<Config> {
+    let is_override = override_path.is_some();
+    let Some(path) = override_path.map(Path::to_path_buf).or_else(config_path) else {
+        return Ok(Config::default_config());
     };
     let contents = match fs::read_to_string(&path) {
         Ok(contents) => contents,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Config::default_config(),
+        Err(error) if !is_override && error.kind() == io::ErrorKind::NotFound => {
+            return Ok(Config::default_config());
+        }
+        Err(error) if is_override => {
+            anyhow::bail!(
+                "elio: failed to read config from {}: {error}",
+                path.display()
+            );
+        }
         Err(error) => {
             eprintln!(
                 "elio: failed to read config from {}: {error}",
                 path.display()
             );
-            return Config::default_config();
+            return Ok(Config::default_config());
         }
     };
 
-    match Config::from_str(&contents) {
+    Ok(match Config::from_str(&contents) {
         Ok(config) => config,
         Err(error) => {
             eprintln!(
@@ -108,19 +123,23 @@ fn load_config_from_disk() -> Config {
             );
             Config::default_config()
         }
-    }
+    })
 }
 
 fn config_path() -> Option<PathBuf> {
     config_dir().map(|dir| dir.join("config.toml"))
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use crate::config::InvokingUser;
+    #[cfg(unix)]
     use std::ffi::OsString;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
+    #[cfg(unix)]
     fn test_user(xdg_config_home: Option<&str>) -> InvokingUser {
         InvokingUser {
             uid: 1000,
@@ -135,6 +154,15 @@ mod tests {
         }
     }
 
+    fn temp_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("elio-config-{label}-{unique}"))
+    }
+
+    #[cfg(unix)]
     #[test]
     fn config_home_follows_invocation_context() {
         let root_default = if cfg!(target_os = "macos") {
@@ -178,5 +206,64 @@ mod tests {
             let actual = config_home_for_context(&context, process_xdg, Some(Path::new("/root")));
             assert_eq!(actual.as_deref(), expected, "context: {context:?}");
         }
+    }
+
+    #[test]
+    fn explicit_config_path_is_loaded() {
+        let root = temp_path("explicit");
+        let path = root.join("custom-settings.toml");
+        fs::create_dir_all(&root).expect("config directory should be created");
+        fs::write(&path, "[ui]\nshow_hidden = true\n").expect("explicit config should be written");
+
+        let config = load_config_from_disk(Some(&path)).expect("explicit config should load");
+
+        assert!(config.ui.show_hidden);
+        fs::remove_dir_all(root).expect("config directory should be removed");
+    }
+
+    #[test]
+    fn missing_explicit_config_path_is_an_error() {
+        let path = temp_path("missing").join("config.toml");
+
+        let error = load_config_from_disk(Some(&path))
+            .err()
+            .expect("missing explicit config should fail");
+
+        assert!(error.to_string().contains(&format!(
+            "elio: failed to read config from {}",
+            path.display()
+        )));
+    }
+
+    #[test]
+    fn unreadable_explicit_config_path_is_an_error() {
+        let root = temp_path("unreadable");
+        let path = root.join("config.toml");
+        fs::create_dir_all(&root).expect("config directory should be created");
+        fs::write(&path, [0xff]).expect("invalid UTF-8 config should be written");
+
+        let error = load_config_from_disk(Some(&path))
+            .err()
+            .expect("unreadable explicit config should fail");
+
+        assert!(error.to_string().contains(&format!(
+            "elio: failed to read config from {}",
+            path.display()
+        )));
+        fs::remove_dir_all(root).expect("config directory should be removed");
+    }
+
+    #[test]
+    fn invalid_explicit_config_falls_back_to_defaults() {
+        let root = temp_path("invalid");
+        let path = root.join("config.toml");
+        fs::create_dir_all(&root).expect("config directory should be created");
+        fs::write(&path, "[ui\nshow_hidden = true\n").expect("invalid config should be written");
+
+        let config =
+            load_config_from_disk(Some(&path)).expect("invalid explicit config should fall back");
+
+        assert!(!config.ui.show_hidden);
+        fs::remove_dir_all(root).expect("config directory should be removed");
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,6 +10,7 @@ mod tests;
 mod ui;
 
 use serde::Deserialize;
+use std::path::Path;
 
 pub(crate) use self::invoking_user::env_var as invoking_user_env_var;
 
@@ -52,11 +53,11 @@ struct ConfigFile {
     open: Option<open::OpenConfigOverride>,
 }
 
-pub(crate) fn initialize() {
+pub(crate) fn initialize(path: Option<&Path>) -> anyhow::Result<()> {
     #[cfg(unix)]
     // Snapshot the invocation context before loading config or starting workers.
     let _ = invoking_user::context();
-    loading::initialize();
+    loading::initialize(path)
 }
 
 pub(crate) fn ui() -> UiConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub fn run_at(cwd: PathBuf) -> Result<()> {
 }
 
 pub fn run_with_options(options: RunOptions) -> Result<()> {
-    runtime::run_with_startup_state(options, None, false, None).map(|_| ())
+    runtime::run_with_startup_state(options, None, false, None, None, None).map(|_| ())
 }
 
 #[doc(hidden)]
@@ -55,11 +55,15 @@ pub fn run_with_startup_options(
     start_focus: Option<PathBuf>,
     reveal_hidden_start_focus: bool,
     chooser_file: Option<PathBuf>,
+    config_file: Option<PathBuf>,
+    theme_file: Option<PathBuf>,
 ) -> Result<RunOutcome> {
     runtime::run_with_startup_state(
         options,
         start_focus,
         reveal_hidden_start_focus,
         chooser_file,
+        config_file,
+        theme_file,
     )
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -91,13 +91,15 @@ pub(crate) fn run_with_startup_state(
     start_focus: Option<PathBuf>,
     reveal_hidden_start_focus: bool,
     chooser_file: Option<PathBuf>,
+    config_file: Option<PathBuf>,
+    theme_file: Option<PathBuf>,
 ) -> Result<RunOutcome> {
     let RunOptions {
         start_dir,
         cwd_file,
     } = options;
-    config::initialize();
-    ui::theme::initialize();
+    config::initialize(config_file.as_deref())?;
+    ui::theme::initialize(theme_file.as_deref())?;
     let (mut terminal, drainer, kitty_dnd) = init_terminal()?;
     let result = run_app(
         &mut terminal,

--- a/src/ui/theme/appearance/loading.rs
+++ b/src/ui/theme/appearance/loading.rs
@@ -1,24 +1,36 @@
 use super::Theme;
 use crate::config;
-use std::{fs, io, path::PathBuf};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
 
-pub(super) fn load_theme_from_disk() -> Theme {
-    let Some(path) = theme_path() else {
-        return Theme::default_theme();
+pub(super) fn load_theme_from_disk(override_path: Option<&Path>) -> anyhow::Result<Theme> {
+    let is_override = override_path.is_some();
+    let Some(path) = override_path.map(Path::to_path_buf).or_else(theme_path) else {
+        return Ok(Theme::default_theme());
     };
     let contents = match fs::read_to_string(&path) {
         Ok(contents) => contents,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Theme::default_theme(),
+        Err(error) if !is_override && error.kind() == io::ErrorKind::NotFound => {
+            return Ok(Theme::default_theme());
+        }
+        Err(error) if is_override => {
+            anyhow::bail!(
+                "elio: failed to read theme from {}: {error}",
+                path.display()
+            );
+        }
         Err(error) => {
             eprintln!(
                 "elio: failed to read theme from {}: {error}",
                 path.display()
             );
-            return Theme::default_theme();
+            return Ok(Theme::default_theme());
         }
     };
 
-    match Theme::from_config_str(&contents) {
+    Ok(match Theme::from_config_str(&contents) {
         Ok(theme) => theme,
         Err(error) => {
             eprintln!(
@@ -27,7 +39,7 @@ pub(super) fn load_theme_from_disk() -> Theme {
             );
             Theme::default_theme()
         }
-    }
+    })
 }
 
 fn theme_path() -> Option<PathBuf> {

--- a/src/ui/theme/appearance/mod.rs
+++ b/src/ui/theme/appearance/mod.rs
@@ -31,8 +31,12 @@ struct EntryClassCache {
 static ACTIVE_THEME: OnceLock<Theme> = OnceLock::new();
 static ENTRY_CLASS_CACHE: OnceLock<Mutex<EntryClassCache>> = OnceLock::new();
 
-pub(crate) fn initialize() {
-    let _ = ACTIVE_THEME.get_or_init(load_theme_from_disk);
+pub(crate) fn initialize(path: Option<&Path>) -> anyhow::Result<()> {
+    if ACTIVE_THEME.get().is_none() {
+        let theme = load_theme_from_disk(path)?;
+        let _ = ACTIVE_THEME.set(theme);
+    }
+    Ok(())
 }
 
 pub(crate) fn palette() -> Palette {

--- a/src/ui/theme/appearance/tests/overrides.rs
+++ b/src/ui/theme/appearance/tests/overrides.rs
@@ -74,7 +74,7 @@ keyword = "#abcdef"
     );
     let _xdg = EnvVarGuard::set_path("XDG_CONFIG_HOME", &config_home);
 
-    let theme = load_theme_from_disk();
+    let theme = load_theme_from_disk(None).expect("theme should load from XDG config home");
 
     assert_eq!(theme.preview.code.keyword, rgb(0xab, 0xcd, 0xef));
     assert_eq!(theme.classes.get(&FileClass::Code).unwrap().icon, "X");
@@ -102,7 +102,7 @@ keyword = "#12"
     );
     let _xdg = EnvVarGuard::set_path("XDG_CONFIG_HOME", &config_home);
 
-    let theme = load_theme_from_disk();
+    let theme = load_theme_from_disk(None).expect("invalid theme should fall back");
     let default_theme = Theme::default_theme();
 
     assert_eq!(theme.palette.bg, default_theme.palette.bg);
@@ -119,6 +119,84 @@ keyword = "#12"
 
     fs::remove_file(path).expect("failed to remove theme file");
     fs::remove_dir_all(config_home).expect("failed to remove config root");
+}
+
+#[test]
+fn load_theme_from_disk_reads_explicit_theme_path() {
+    let root = temp_path("load-explicit-theme");
+    let path = root.join("custom-theme.toml");
+    fs::create_dir_all(&root).expect("failed to create explicit theme directory");
+    fs::write(
+        &path,
+        r##"
+[preview.code]
+keyword = "#123456"
+"##,
+    )
+    .expect("failed to write explicit theme file");
+
+    let theme = load_theme_from_disk(Some(&path)).expect("explicit theme should load");
+
+    assert_eq!(theme.preview.code.keyword, rgb(0x12, 0x34, 0x56));
+    fs::remove_dir_all(root).expect("failed to remove explicit theme directory");
+}
+
+#[test]
+fn missing_explicit_theme_path_is_an_error() {
+    let path = temp_path("missing-explicit-theme").join("theme.toml");
+
+    let error = load_theme_from_disk(Some(&path))
+        .err()
+        .expect("missing explicit theme should fail");
+
+    assert!(error.to_string().contains(&format!(
+        "elio: failed to read theme from {}",
+        path.display()
+    )));
+}
+
+#[test]
+fn unreadable_explicit_theme_path_is_an_error() {
+    let root = temp_path("unreadable-explicit-theme");
+    let path = root.join("theme.toml");
+    fs::create_dir_all(&root).expect("failed to create explicit theme directory");
+    fs::write(&path, [0xff]).expect("failed to write invalid UTF-8 theme");
+
+    let error = load_theme_from_disk(Some(&path))
+        .err()
+        .expect("unreadable explicit theme should fail");
+
+    assert!(error.to_string().contains(&format!(
+        "elio: failed to read theme from {}",
+        path.display()
+    )));
+    fs::remove_dir_all(root).expect("failed to remove explicit theme directory");
+}
+
+#[test]
+fn invalid_explicit_theme_falls_back_to_default_theme() {
+    let root = temp_path("invalid-explicit-theme");
+    let path = root.join("theme.toml");
+    fs::create_dir_all(&root).expect("failed to create explicit theme directory");
+    fs::write(
+        &path,
+        r##"
+[preview.code]
+keyword = "#12"
+"##,
+    )
+    .expect("failed to write invalid explicit theme");
+
+    let theme = load_theme_from_disk(Some(&path))
+        .expect("invalid explicit theme should fall back to the default");
+    let default_theme = Theme::default_theme();
+
+    assert_eq!(theme.palette.bg, default_theme.palette.bg);
+    assert_eq!(
+        theme.preview.code.keyword,
+        default_theme.preview.code.keyword
+    );
+    fs::remove_dir_all(root).expect("failed to remove explicit theme directory");
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -35,9 +35,13 @@ fn help_prints_usage() {
         "[PATH]               Start in a directory, or focus a file in its parent directory"
     ));
     assert!(stdout.contains("--chooser-file FILE  Write chosen paths to FILE, or stdout with '-'"));
-    assert!(stdout.contains("--cwd-file FILE  Write the final current directory to FILE on exit"));
-    assert!(stdout.contains("-h, --help           Print help"));
-    assert!(stdout.contains("-V, --version        Print version"));
+    assert!(stdout.contains("--config FILE        Load configuration from FILE"));
+    assert!(
+        stdout.contains("--cwd-file FILE      Write the final current directory to FILE on exit")
+    );
+    assert!(stdout.contains("--theme FILE         Load theme from FILE"));
+    assert!(stdout.contains("-h, --help               Print help"));
+    assert!(stdout.contains("-V, --version            Print version"));
     assert!(stdout.contains("Commands:"));
     assert!(
         stdout.contains(
@@ -80,6 +84,174 @@ fn mistyped_chooser_file_flag_exits_with_suggestion() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("error: unexpected argument '--chooser' found"));
     assert!(stderr.contains("tip: a similar argument exists: '--chooser-file'"));
+}
+
+#[test]
+fn mistyped_config_flag_exits_with_suggestion() {
+    let output = elio()
+        .arg("--conf")
+        .output()
+        .expect("failed to run elio --conf");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("error: unexpected argument '--conf' found"));
+    assert!(stderr.contains("tip: a similar argument exists: '--config'"));
+}
+
+#[test]
+fn mistyped_theme_flag_exits_with_suggestion() {
+    let output = elio()
+        .arg("--them")
+        .output()
+        .expect("failed to run elio --them");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("error: unexpected argument '--them' found"));
+    assert!(stderr.contains("tip: a similar argument exists: '--theme'"));
+}
+
+#[test]
+fn config_and_theme_do_not_have_short_flags() {
+    for flag in ["-c", "-t"] {
+        let output = elio()
+            .arg(flag)
+            .output()
+            .unwrap_or_else(|error| panic!("failed to run elio {flag}: {error}"));
+
+        assert!(!output.status.success());
+        assert!(output.stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(&output.stderr)
+                .contains(&format!("error: unexpected argument '{flag}' found"))
+        );
+    }
+}
+
+#[test]
+fn config_requires_value() {
+    let output = elio()
+        .arg("--config")
+        .output()
+        .expect("failed to run elio --config");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("error: expected a file path after '--config'")
+    );
+}
+
+#[test]
+fn config_equals_requires_value() {
+    let output = elio()
+        .arg("--config=")
+        .output()
+        .expect("failed to run elio --config=");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("error: expected a file path after '--config'")
+    );
+}
+
+#[test]
+fn theme_requires_value() {
+    let output = elio()
+        .arg("--theme")
+        .output()
+        .expect("failed to run elio --theme");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("error: expected a file path after '--theme'")
+    );
+}
+
+#[test]
+fn theme_equals_requires_value() {
+    let output = elio()
+        .arg("--theme=")
+        .output()
+        .expect("failed to run elio --theme=");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("error: expected a file path after '--theme'")
+    );
+}
+
+#[test]
+fn duplicate_config_is_rejected() {
+    let output = elio()
+        .args(["--config", "first.toml", "--config=second.toml"])
+        .output()
+        .expect("failed to run elio with duplicate --config");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("error: '--config' cannot be used more than once")
+    );
+}
+
+#[test]
+fn duplicate_theme_is_rejected() {
+    let output = elio()
+        .args(["--theme", "first.toml", "--theme=second.toml"])
+        .output()
+        .expect("failed to run elio with duplicate --theme");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("error: '--theme' cannot be used more than once")
+    );
+}
+
+#[test]
+fn missing_explicit_config_fails_before_terminal_startup() {
+    let path = temp_path("missing-explicit-config").join("config.toml");
+    let output = elio()
+        .arg(format!("--config={}", path.display()))
+        .output()
+        .expect("failed to run elio with missing explicit config");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains(&format!(
+        "elio: failed to read config from {}",
+        path.display()
+    )));
+}
+
+#[test]
+fn missing_explicit_theme_fails_before_terminal_startup() {
+    let path = temp_path("missing-explicit-theme").join("theme.toml");
+    let output = elio()
+        .arg("--theme")
+        .arg(&path)
+        .output()
+        .expect("failed to run elio with missing explicit theme");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains(&format!(
+        "elio: failed to read theme from {}",
+        path.display()
+    )));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add `--config FILE` and `--theme FILE` to load configuration and themes from custom paths.

Explicit paths replace the default lookup for their respective file. Missing or unreadable files fail at startup, while existing parsing and fallback behavior remains unchanged.

Closes #274.

## Testing

Verified with:

- [x] `cargo fmt --check`
- [x] `cargo test --locked --test architecture_guardrails`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- [x] `cargo check --target i686-unknown-linux-gnu`

Manual checks:

- Launched config and theme overrides separately and together, from the same and different directories, using conventional and arbitrary filenames, reordered/inline flags, and other run options.
- Confirmed malformed TOML and invalid values preserve existing diagnostics and fallback behavior, with elio launching normally and errors remaining visible after exit.
- Confirmed missing files, directory paths, and permission-denied files fail before terminal startup with path-specific errors instead of falling back to default locations.