### PR TITLE
fix(preview): avoid creating SQLite WAL sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed image previews disappearing after returning from actions that suspend and restore the TUI.
 - Fixed pasted text being handled as normal keystrokes.
 - Fixed stretched image previews in Kitty graphics environments that do not preserve placeholder aspect ratios. ([#267])
+- Fixed SQLite previews creating missing `-wal` and `-shm` sidecar files for WAL-mode databases. ([#278])
 
 ## [1.11.2] - 2026-07-22
 
@@ -331,6 +332,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/elio-fm/elio/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/elio-fm/elio/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/elio-fm/elio/releases/tag/v1.0.0
+[#278]: https://github.com/elio-fm/elio/issues/278
 [#274]: https://github.com/elio-fm/elio/issues/274
 [#270]: https://github.com/elio-fm/elio/issues/270
 [#267]: https://github.com/elio-fm/elio/issues/267

--- a/src/preview/data/sqlite.rs
+++ b/src/preview/data/sqlite.rs
@@ -1,6 +1,11 @@
 use super::*;
 use rusqlite::{Connection, OpenFlags, types::ValueRef};
-use std::{fs::File, io::Read, path::Path};
+use std::{
+    ffi::OsString,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+};
 
 const SQLITE_MAGIC: &[u8; 16] = b"SQLite format 3\x00";
 const MAX_TABLES: usize = 40;
@@ -37,11 +42,7 @@ pub(in crate::preview) fn build_sqlite_preview(path: &Path) -> Option<PreviewCon
     }
 
     let header = parse_header(&raw);
-    let conn = Connection::open_with_flags(
-        path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )
-    .ok()?;
+    let conn = open_preview_connection(path, header.write_version == 2)?;
 
     let palette = theme::palette();
     let mut lines = Vec::new();
@@ -146,6 +147,95 @@ fn read_header_bytes(path: &Path) -> Option<[u8; 100]> {
     let mut buf = [0u8; 100];
     File::open(path).ok()?.read_exact(&mut buf).ok()?;
     Some(buf)
+}
+
+fn open_preview_connection(path: &Path, is_wal: bool) -> Option<Connection> {
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX;
+    if !is_wal {
+        return Connection::open_with_flags(path, flags).ok();
+    }
+
+    // SQLite opens sidecars beside the target database, not beside a symlink.
+    let path = path.canonicalize().ok()?;
+    let wal_exists = sidecar_path(&path, "-wal").try_exists().ok()?;
+    let shm_exists = sidecar_path(&path, "-shm").try_exists().ok()?;
+
+    match (wal_exists, shm_exists) {
+        // A partial sidecar set would make SQLite create the missing file.
+        (true, false) | (false, true) => None,
+        // Existing sidecars may contain committed data that immutable mode ignores.
+        (true, true) => Connection::open_with_flags(&path, flags).ok(),
+        // With no sidecars, immutable mode avoids creating empty WAL/SHM files.
+        (false, false) => {
+            Connection::open_with_flags(immutable_uri(&path)?, flags | OpenFlags::SQLITE_OPEN_URI)
+                .ok()
+        }
+    }
+}
+
+fn sidecar_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut sidecar = OsString::from(path.as_os_str());
+    sidecar.push(suffix);
+    PathBuf::from(sidecar)
+}
+
+fn immutable_uri(path: &Path) -> Option<String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        let mut uri = String::from("file:");
+        append_uri_encoded(&mut uri, path.as_os_str().as_bytes());
+        uri.push_str("?immutable=1");
+        Some(uri)
+    }
+
+    #[cfg(windows)]
+    {
+        let mut normalized = path.to_str()?.replace('\\', "/");
+        if let Some(path) = normalized.strip_prefix("//?/UNC/") {
+            normalized = format!("//{path}");
+        } else if let Some(path) = normalized.strip_prefix("//?/") {
+            normalized = path.to_string();
+        }
+
+        let mut uri = if let Some(unc) = normalized.strip_prefix("//") {
+            let mut uri = String::from("file:////");
+            append_uri_encoded(&mut uri, unc.as_bytes());
+            uri
+        } else if normalized.as_bytes().get(1) == Some(&b':')
+            && normalized.as_bytes().get(2) == Some(&b'/')
+            && normalized.as_bytes()[0].is_ascii_alphabetic()
+        {
+            let mut uri = String::from("file:/");
+            append_uri_encoded(&mut uri, normalized.as_bytes());
+            uri
+        } else {
+            return None;
+        };
+        uri.push_str("?immutable=1");
+        Some(uri)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let mut uri = String::from("file:");
+        append_uri_encoded(&mut uri, path.to_str()?.as_bytes());
+        uri.push_str("?immutable=1");
+        Some(uri)
+    }
+}
+
+fn append_uri_encoded(uri: &mut String, bytes: &[u8]) {
+    for &byte in bytes {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b'/' | b':') {
+            uri.push(byte as char);
+        } else {
+            const HEX: &[u8; 16] = b"0123456789ABCDEF";
+            uri.push('%');
+            uri.push(HEX[(byte >> 4) as usize] as char);
+            uri.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+    }
 }
 
 fn parse_header(raw: &[u8; 100]) -> SqliteHeader {
@@ -440,4 +530,22 @@ fn muted_line(text: &str, palette: theme::Palette) -> Line<'static> {
         text.to_string(),
         Style::default().fg(palette.muted),
     ))
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn immutable_uri_handles_windows_drive_and_unc_paths() {
+        assert_eq!(
+            immutable_uri(Path::new(r"C:\dbs\a #1%.db")).as_deref(),
+            Some("file:/C:/dbs/a%20%231%25.db?immutable=1")
+        );
+        assert_eq!(
+            immutable_uri(Path::new(r"\\server\share\a.db")).as_deref(),
+            Some("file:////server/share/a.db?immutable=1")
+        );
+        assert!(immutable_uri(Path::new(r"C:relative.db")).is_none());
+    }
 }

--- a/src/preview/tests/data.rs
+++ b/src/preview/tests/data.rs
@@ -118,7 +118,7 @@ fn sqlite_preview_does_not_create_wal_sidecars() {
     fs::remove_dir_all(root).expect("failed to remove temp root");
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 #[test]
 fn sqlite_preview_handles_non_utf8_wal_paths_without_sidecars() {
     use std::os::unix::ffi::OsStringExt;

--- a/src/preview/tests/data.rs
+++ b/src/preview/tests/data.rs
@@ -93,6 +93,138 @@ fn sqlite_preview_shows_header_and_tables() {
 }
 
 #[test]
+fn sqlite_preview_does_not_create_wal_sidecars() {
+    let root = temp_path("sqlite-wal-no-sidecars");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join("cash #100%.sqlite");
+    let conn = Connection::open(&path).expect("failed to open sqlite db");
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .expect("failed to enable WAL mode");
+    conn.execute("CREATE TABLE items (name TEXT NOT NULL)", [])
+        .expect("failed to create table");
+    drop(conn);
+
+    let wal = root.join("cash #100%.sqlite-wal");
+    let shm = root.join("cash #100%.sqlite-shm");
+    assert!(!wal.exists());
+    assert!(!shm.exists());
+
+    let preview = build_preview(&file_entry(path));
+    let text: Vec<String> = preview.lines().iter().map(line_text).collect();
+    assert!(text.iter().any(|line| line.contains("items")), "{text:?}");
+    assert!(!wal.exists(), "SQLite preview created {}", wal.display());
+    assert!(!shm.exists(), "SQLite preview created {}", shm.display());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[cfg(unix)]
+#[test]
+fn sqlite_preview_handles_non_utf8_wal_paths_without_sidecars() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let root = temp_path("sqlite-wal-non-utf8");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let path = root.join(std::ffi::OsString::from_vec(b"cash-\xff.sqlite".to_vec()));
+    let conn = Connection::open(&path).expect("failed to open sqlite db");
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .expect("failed to enable WAL mode");
+    conn.execute("CREATE TABLE items (name TEXT NOT NULL)", [])
+        .expect("failed to create table");
+    drop(conn);
+
+    let preview = build_preview(&file_entry(path.clone()));
+    let text: Vec<String> = preview.lines().iter().map(line_text).collect();
+    assert!(text.iter().any(|line| line.contains("items")), "{text:?}");
+    let mut wal = path.as_os_str().to_os_string();
+    wal.push("-wal");
+    let mut shm = path.as_os_str().to_os_string();
+    shm.push("-shm");
+    assert!(!std::path::PathBuf::from(wal).exists());
+    assert!(!std::path::PathBuf::from(shm).exists());
+
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
+fn sqlite_preview_reads_active_wal_and_rejects_partial_sidecars() {
+    let root = temp_path("sqlite-active-wal");
+    let source_dir = root.join("source");
+    let copy_dir = root.join("copy");
+    fs::create_dir_all(&source_dir).expect("failed to create source dir");
+    fs::create_dir_all(&copy_dir).expect("failed to create copy dir");
+    let source = source_dir.join("source.sqlite");
+    let conn = Connection::open(&source).expect("failed to open sqlite db");
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .expect("failed to enable WAL mode");
+    conn.pragma_update(None, "wal_autocheckpoint", 0)
+        .expect("failed to disable checkpoints");
+    conn.execute_batch(
+        "CREATE TABLE messages (body TEXT NOT NULL);
+         INSERT INTO messages VALUES ('committed in WAL');",
+    )
+    .expect("failed to populate database");
+
+    let preview = build_preview(&file_entry(source.clone()));
+    let text: Vec<String> = preview.lines().iter().map(line_text).collect();
+    assert!(
+        text.iter().any(|line| line.contains("committed in WAL")),
+        "active WAL data was omitted: {text:?}"
+    );
+
+    let copy = copy_dir.join("copy.sqlite");
+    let copy_wal = copy_dir.join("copy.sqlite-wal");
+    let copy_shm = copy_dir.join("copy.sqlite-shm");
+    fs::copy(&source, &copy).expect("failed to copy database");
+    fs::copy(source_dir.join("source.sqlite-wal"), &copy_wal).expect("failed to copy WAL");
+    assert!(crate::preview::data::build_sqlite_preview(&copy).is_none());
+    assert!(!copy_shm.exists(), "preview created the missing SHM");
+
+    fs::remove_file(&copy_wal).expect("failed to remove WAL");
+    fs::copy(source_dir.join("source.sqlite-shm"), &copy_shm).expect("failed to copy SHM");
+    assert!(crate::preview::data::build_sqlite_preview(&copy).is_none());
+    assert!(!copy_wal.exists(), "preview created the missing WAL");
+
+    drop(conn);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[cfg(unix)]
+#[test]
+fn sqlite_preview_reads_active_wal_through_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_path("sqlite-wal-symlink");
+    fs::create_dir_all(&root).expect("failed to create temp root");
+    let source = root.join("source.sqlite");
+    let link = root.join("linked.sqlite");
+    let conn = Connection::open(&source).expect("failed to open sqlite db");
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .expect("failed to enable WAL mode");
+    conn.pragma_update(None, "wal_autocheckpoint", 0)
+        .expect("failed to disable checkpoints");
+    conn.execute_batch(
+        "CREATE TABLE messages (body TEXT NOT NULL);
+         INSERT INTO messages VALUES ('visible through symlink');",
+    )
+    .expect("failed to populate database");
+    symlink(&source, &link).expect("failed to create symlink");
+
+    let preview = build_preview(&file_entry(link));
+    let text: Vec<String> = preview.lines().iter().map(line_text).collect();
+    assert!(
+        text.iter()
+            .any(|line| line.contains("visible through symlink")),
+        "symlink preview omitted WAL data: {text:?}"
+    );
+    assert!(!root.join("linked.sqlite-wal").exists());
+    assert!(!root.join("linked.sqlite-shm").exists());
+
+    drop(conn);
+    fs::remove_dir_all(root).expect("failed to remove temp root");
+}
+
+#[test]
 fn sqlite_preview_shows_views() {
     let root = temp_path("sqlite-view");
     fs::create_dir_all(&root).expect("failed to create temp root");


### PR DESCRIPTION
## Summary

Prevent SQLite previews from creating missing `-wal` and `-shm` sidecar files for WAL-mode databases.

Databases with both sidecars present continue using normal read-only handling, while WAL databases without sidecars are opened immutably. Immutable SQLite URIs encode special-character paths correctly on Unix and Windows.

Closes #278.

## Testing

Verified with:

* [x] `cargo fmt --check`
* [x] `cargo test --locked --test architecture_guardrails`
* [x] `cargo clippy --locked --all-targets -- -D warnings`
* [x] `cargo test --locked`
* [x] `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
* [x] `cargo check --target i686-unknown-linux-gnu`

Manual checks:

* Reproduced the issue with elio 1.11.2: opening a WAL-mode database with no sidecars created the `-wal` and `-shm`.
* Verified the branch previews the same database without creating either sidecar and leaves the main database file unchanged.
* Verified that, with both sidecars present, corrupt-WAL preview behavior remains consistent with elio 1.11.2.
